### PR TITLE
git + gitflow compatibility

### DIFF
--- a/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
+++ b/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
@@ -213,7 +213,7 @@ public class SonarRunnerBuilder extends Builder {
     if (!populateConfiguration(argsBuilder, build, listener, env, getSonarInstallation())) {
       return false;
     }
-  
+
     // Java
     computeJdkToUse(build, listener, env);
 


### PR DESCRIPTION
Gitflow, and indeed git branches generally often have forward slashes in their branch name. For example origin/develop or feature/my-feature. Sonar does not accept branch names containing a forward slash as being valid. This pull request contains code to make branches such as the examples mentioned compatible with Sonar by substituting forward slashes for hyphens.
