### PR TITLE
Allow using of environment variables in project version

### DIFF
--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
@@ -120,9 +120,11 @@ public class MsBuildSQRunnerBegin extends AbstractMsBuildSQRunner {
   private void addArgsTo(ArgumentListBuilder args, SonarInstallation sonarInst, EnvVars env, Map<String, String> props) {
     args.add("begin");
 
+    String expandedProjectVersion = env.expand(projectVersion);
+	
     args.add("/k:" + projectKey + "");
     args.add("/n:" + projectName + "");
-    args.add("/v:" + projectVersion + "");
+    args.add("/v:" + expandedProjectVersion + "");
 
     // expand macros using itself
     EnvVars.resolve(props);


### PR DESCRIPTION
if you add a "SonarQube Scanner for MSBuild - Begin Analysis" step to your build you have to define a project version. Currently it is not possible to use jenkins environment variables in this field. So you have to define the project version and have to manually edit the build definition if the version changes.
My commit replaces environment variables in the project version. Now you can provide the version number dynamically.

