### PR TITLE
Better support of environment variables in the MSBuild Scanner config

### DIFF
--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
@@ -127,9 +127,9 @@ public class MsBuildSQRunnerBegin extends AbstractMsBuildSQRunner {
   private void addArgsTo(ArgumentListBuilder args, SonarInstallation sonarInst, EnvVars env, Map<String, String> props) {
     args.add("begin");
 
-    args.add("/k:" + projectKey + "");
-    args.add("/n:" + projectName + "");
-    args.add("/v:" + projectVersion + "");
+    args.add("/k:" + env.expand(projectKey) + "");
+    args.add("/n:" + env.expand(projectName) + "");
+    args.add("/v:" + env.expand(projectVersion) + "");
 
     // expand macros using itself
     EnvVars.resolve(props);


### PR DESCRIPTION
With this change will be possible to use environment variables for the project key, name and version in the configuration section of "SonarQube Scanner for MSBuild - Begin Analysis".

Please see: https://groups.google.com/d/msg/sonarqube/jW2t_99z5ww/bED6fayoAwAJ