### PR TITLE
Update of Confluence help links.

### DIFF
--- a/src/main/webapp/help-ms-build-sq-scanner-begin.html
+++ b/src/main/webapp/help-ms-build-sq-scanner-begin.html
@@ -3,6 +3,6 @@
 		Fetch analysis settings from SonarQube.<br /> After rebuilding the
 		project, it should be followed by an invocation of <b>SonarQube Scanner for MSBuild End Analysis</b>.<br /> For more information, check the
 		<a
-			href="http://docs.sonarqube.org/display/SONAR/Analyzing+with+MSBuild+SonarQube+Runner">documentation</a>.
+			href="http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+MSBuild">documentation</a>.
 	</p>
 </div>

--- a/src/main/webapp/help-ms-build-sq-scanner-end.html
+++ b/src/main/webapp/help-ms-build-sq-scanner-end.html
@@ -3,6 +3,6 @@
 		Upload analysis results to SonarQube. <br /> It should be preceded by
 		an invocation of <b>SonarQube Scanner for MSBuild End Analysis</b> and a
 		rebuild of the project.<br /> For more information, check the <a
-			href="http://docs.sonarqube.org/display/SONAR/Analyzing+with+MSBuild+SonarQube+Runner">documentation</a>.
+			href="http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+MSBuild">documentation</a>.
 	</p>
 </div>

--- a/src/main/webapp/help-runner-installation.html
+++ b/src/main/webapp/help-runner-installation.html
@@ -2,6 +2,6 @@
   <p>
     Mandatory.<br/>
     SonarQube Scanner to use to launch the analysis.<br/>
-    To manage SonarQube Scanners, see <a target="_new" href="http://docs.sonarqube.org/display/SONAR/Analyzing+with+SonarQube+Scanner+for+Jenkins#AnalyzingwithSonarQubeScannerforJenkins-AddingSonarQubeScanner">Configuring Jenkins SonarQube Plugin</a>.
+    To manage SonarQube Scanners, see <a target="_new" href="http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+Jenkins#AnalyzingwithSonarQubeScannerforJenkins-AddingSonarQubeScanner">Configuring Jenkins SonarQube Plugin</a>.
   </p>
 </div>

--- a/src/main/webapp/help-sonar-installation.html
+++ b/src/main/webapp/help-sonar-installation.html
@@ -2,6 +2,6 @@
   <p>
     Mandatory.<br/>
     SonarQube installation to use.<br/>
-    To manage SonarQube installations, see <a target="_new" href="http://docs.sonarqube.org/display/PLUG/Configuring+Jenkins+SonarQube+Plugin#ConfiguringJenkinsSonarQubePlugin-AddingSonarQubeServer">Configuring Jenkins SonarQube Plugin</a>.
+    To manage SonarQube installations, see <a target="_new" href="http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+Jenkins#AnalyzingwithSonarQubeScannerforJenkins-AddingSonarQubeServer">Configuring Jenkins SonarQube Plugin</a>.
   </p>
 </div>

--- a/src/main/webapp/help-sonar-publisher.html
+++ b/src/main/webapp/help-sonar-publisher.html
@@ -2,6 +2,6 @@
 	<p>
 	This build action is deprecated. Instead, the recommended way to run an analysis with Maven is to use SonarQube environment variable injection with a standard Maven build step to run the sonar:sonar goal.
 	<br/>
-	More information, see <a target="_new" href="http://docs.sonarqube.org/display/SONAR/Analyzing+with+SonarQube+Scanner+for+Jenkins#AnalyzingwithSonarQubeScannerforJenkins-ConfiguringaSonarQubeScannerusingenvironmentvariables">Configuring Jenkins SonarQube Plugin</a>.
+	More information, see <a target="_new" href="http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+Jenkins#AnalyzingwithSonarQubeScannerforJenkins-ConfiguringaSonarQubeScannerusingenvironmentvariables">Configuring Jenkins SonarQube Plugin</a>.
 	</p>
 </div>


### PR DESCRIPTION
The names and locations in sonarqube's Confluence changed but the links in this plugin did not which leads to 404 errors if someone clicks the help buttons