### PR TITLE
Extend Sonar icon display name

### DIFF
--- a/src/main/java/hudson/plugins/sonar/action/SonarBuildBadgeAction.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarBuildBadgeAction.java
@@ -23,6 +23,7 @@ import hudson.plugins.sonar.SonarPlugin;
 
 import hudson.PluginWrapper;
 import hudson.model.BuildBadgeAction;
+import hudson.plugins.sonar.utils.SonarUtils;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -37,13 +38,18 @@ import org.kohsuke.stapler.export.ExportedBean;
 public final class SonarBuildBadgeAction implements BuildBadgeAction {
 
   private final String url;
+  private final String displayName;
 
   public SonarBuildBadgeAction() {
     this.url = null;
+    this.displayName = Messages.SonarAction_Sonar();
   }
 
-  public SonarBuildBadgeAction(String url) {
+  public SonarBuildBadgeAction(String url, boolean extended) {
     this.url = url;
+    String projectName = extended ? SonarUtils.extractSonarProjectNameFromURL(url) : null;
+    String suffix = projectName == null ? "" : (": " + projectName);
+    this.displayName = Messages.SonarAction_Sonar() + suffix;
   }
 
   public String getTooltip() {
@@ -52,7 +58,7 @@ public final class SonarBuildBadgeAction implements BuildBadgeAction {
 
   @Override
   public String getDisplayName() {
-    return Messages.SonarAction_Sonar();
+    return displayName;
   }
 
   public String getIcon() {

--- a/src/main/java/hudson/plugins/sonar/action/SonarBuildBadgeActionFactory.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarBuildBadgeActionFactory.java
@@ -67,6 +67,6 @@ public class SonarBuildBadgeActionFactory extends TransientActionFactory<Run> {
       }
     }
 
-    return Collections.singletonList(new SonarBuildBadgeAction(url));
+    return Collections.singletonList(new SonarBuildBadgeAction(url, actions.size() > 1));
   }
 }

--- a/src/main/java/hudson/plugins/sonar/action/SonarProjectActionFactory.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarProjectActionFactory.java
@@ -69,10 +69,11 @@ public class SonarProjectActionFactory extends TransientActionFactory<AbstractPr
     Run<?, ?> lastBuild = project.getLastCompletedBuild();
 
     if (lastBuild != null) {
-      for (SonarAnalysisAction a : lastBuild.getActions(SonarAnalysisAction.class)) {
+      List<SonarAnalysisAction> sonarAnalysisActions = lastBuild.getActions(SonarAnalysisAction.class);
+      for (SonarAnalysisAction a : sonarAnalysisActions) {
         if (a.getUrl() != null && !urls.contains(a.getUrl())) {
           urls.add(a.getUrl());
-          sonarProjectActions.add(new SonarProjectIconAction(a));
+          sonarProjectActions.add(new SonarProjectIconAction(a, sonarAnalysisActions.size() > 1));
           filteredActions.add(a);
         }
       }

--- a/src/main/java/hudson/plugins/sonar/action/SonarProjectIconAction.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarProjectIconAction.java
@@ -22,6 +22,7 @@ import hudson.plugins.sonar.Messages;
 import hudson.plugins.sonar.SonarPlugin;
 import hudson.PluginWrapper;
 import hudson.model.ProminentProjectAction;
+import hudson.plugins.sonar.utils.SonarUtils;
 import jenkins.model.Jenkins;
 
 /**
@@ -31,14 +32,20 @@ import jenkins.model.Jenkins;
  * @since 1.2
  */
 public final class SonarProjectIconAction implements ProminentProjectAction {
+
   private final SonarAnalysisAction buildInfo;
+  private final String displayName;
 
   public SonarProjectIconAction() {
     this.buildInfo = null;
+    this.displayName = Messages.SonarAction_Sonar();
   }
 
-  public SonarProjectIconAction(SonarAnalysisAction buildInfo) {
+  public SonarProjectIconAction(SonarAnalysisAction buildInfo, boolean extended) {
     this.buildInfo = buildInfo;
+    String projectName = extended ? SonarUtils.extractSonarProjectNameFromURL(buildInfo.getUrl()) : null;
+    String suffix = projectName == null ? "" : (": " + projectName);
+    this.displayName = Messages.SonarAction_Sonar() + suffix;
   }
 
   @Override
@@ -50,7 +57,7 @@ public final class SonarProjectIconAction implements ProminentProjectAction {
 
   @Override
   public String getDisplayName() {
-    return Messages.SonarAction_Sonar();
+    return displayName;
   }
 
   @Override

--- a/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
@@ -62,6 +62,11 @@ public final class SonarUtils {
     return extractPatternFromLogs(URL_PATTERN_IN_LOGS, build);
   }
 
+  public static String extractSonarProjectNameFromURL(String url) {
+    int index = url == null ? 0 : url.lastIndexOf("/");
+    return index > 0 ? url.substring(index + 1) : null;
+  }
+
   public static <T extends Action> List<T> getPersistentActions(Actionable actionable, Class<T> type) {
     List<T> filtered = new LinkedList<>();
 

--- a/src/test/java/hudson/plugins/sonar/action/SonarProjectIconActionTest.java
+++ b/src/test/java/hudson/plugins/sonar/action/SonarProjectIconActionTest.java
@@ -35,7 +35,7 @@ public class SonarProjectIconActionTest extends SonarTestCase {
   @Test
   public void test() throws Exception {
     AbstractProject project = mock(AbstractProject.class);
-    SonarProjectIconAction action = new SonarProjectIconAction(new SonarAnalysisAction("inst"));
+    SonarProjectIconAction action = new SonarProjectIconAction(new SonarAnalysisAction("inst"), false);
     when(project.getBuilds()).thenReturn(new RunList());
     assertThat(action.getDisplayName()).isNotNull();
     assertThat(action.getIconFileName()).isNotNull();

--- a/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
@@ -140,7 +140,7 @@ public class SonarUtilsTest {
 
   private Run<?, ?> mockedRunWithSonarAction(String url) throws IOException {
     Run<?, ?> build = mock(Run.class);
-    when(build.getAction(SonarBuildBadgeAction.class)).thenReturn(url != null ? new SonarBuildBadgeAction(url) : null);
+    when(build.getAction(SonarBuildBadgeAction.class)).thenReturn(url != null ? new SonarBuildBadgeAction(url, false) : null);
     return build;
   }
 


### PR DESCRIPTION
When a Jenkins job triggers multiple SonarQube analysis (e.g. Maven project with modules), the user cannot distinguish easily between several identical icons. This PR extracts the project name from the URL and adds it to the display name only when there is more than one link.