### PR TITLE
Removed obsolete option

### DIFF
--- a/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
+++ b/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
@@ -362,10 +362,6 @@ public class SonarRunnerBuilder extends Builder {
     args.addTokenized(inst.getAdditionalProperties());
     args.add(inst.getAdditionalAnalysisPropertiesUnix());
     args.addTokenized(additionalArguments);
-
-    if (!args.toList().contains("-e")) {
-      args.add("-e");
-    }
   }
 
   private void addTaskArgument(ArgumentListBuilder args) {

--- a/src/test/java/hudson/plugins/sonar/SonarRunnerBuilderTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarRunnerBuilderTest.java
@@ -114,7 +114,7 @@ public class SonarRunnerBuilderTest extends SonarTestCase {
     builder = new SonarRunnerBuilder(null, null, "myCustomProjectSettings.properties", null, null, null, null, "-X");
     args.clear();
     builder.addAdditionalArguments(args, inst);
-    assertThat(args.toString()).isEqualTo("-Y -Dkey=value -X -e");
+    assertThat(args.toString()).isEqualTo("-Y -Dkey=value -X");
 
   }
 


### PR DESCRIPTION
`INFO: Option -e/--errors is no longer supported and will be ignored`

We're using latest sonar-scanner for jenkins and I'm seeing the line above in every build log (while we're using default scanner options). I guess we should remove that option.