### PR TITLE
Do not parse build log but explicitly tell the Maven plugin where to put its report

### DIFF
--- a/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
@@ -144,6 +144,9 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
 
     map.put("SONAR_EXTRA_PROPS", getOrDefault(getAdditionalProps(inst), ""));
 
+    String workingDir = reportDir.getRemote();
+    map.put("SONAR_WORKING_DIRECTORY", workingDir);
+    
     StringBuilder sb = new StringBuilder();
     sb.append("{ \"sonar.host.url\" : \"").append(StringEscapeUtils.escapeJson(hostUrl)).append("\"");
     if (!login.isEmpty() || !token.isEmpty()) {
@@ -153,7 +156,7 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
       sb.append(", \"sonar.password\" : \"").append(StringEscapeUtils.escapeJson(password)).append("\"");
     }
     if (reportDir!=null) {
-    	sb.append(", \"sonar.working.directory\" : \"").append(reportDir.getRemote() + "\"");
+    	sb.append(", \"sonar.working.directory\" : \"").append(StringEscapeUtils.escapeJson(workingDir)).append("\"");
     }
     sb.append("}");
 

--- a/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
@@ -111,6 +111,12 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
   }
 
   @VisibleForTesting
+  @Deprecated
+  static Map<String, String> createVars(SonarInstallation inst) {
+	  return createVars(inst, null);
+  }
+  
+  @VisibleForTesting
   static Map<String, String> createVars(SonarInstallation inst, FilePath reportDir) {
     Map<String, String> map = new HashMap<>();
 
@@ -146,7 +152,9 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
     if (!password.isEmpty()) {
       sb.append(", \"sonar.password\" : \"").append(StringEscapeUtils.escapeJson(password)).append("\"");
     }
-    sb.append(", \"sonar.working.directory\" : \"").append(reportDir.getRemote() + "\"");
+    if (reportDir!=null) {
+    	sb.append(", \"sonar.working.directory\" : \"").append(reportDir.getRemote() + "\"");
+    }
     sb.append("}");
 
     map.put("SONARQUBE_SCANNER_PARAMS", sb.toString());


### PR DESCRIPTION
This PR is all about avoiding to parse the build logs to discover where the Maven plugin may have put its report file. In short the modified version does the following:
- Ask Jenkins for a temporary directory alongside the workspace to host the report generated by the Maven sonar plugin.
- Use `sonar.working.directory` to tell the Maven plugin where to put its report file.
- Consume the report file during `tearDown()` from that location without having to parse the build log to find it back...
- Delete the report folder on completion