### PR TITLE
Changed 'locahost' to 'localhost' in default_server_url

### DIFF
--- a/src/main/java/hudson/plugins/sonar/SonarInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/SonarInstallation.java
@@ -52,7 +52,7 @@ public class SonarInstallation implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  public static final String DEFAULT_SERVER_URL = "http://locahost:9000";
+  public static final String DEFAULT_SERVER_URL = "http://localhost:9000";
 
   private final String name;
   private final String serverUrl;


### PR DESCRIPTION
When configuring the jenkins plugin it states "Default is http://localhost:9000", but if the Server URL field is left blank 'locahost:9000' is used - causing the build pipeline to fail with an exception - unknown host - and a stack trace. 

I have version 2.6.1 installed, Jenkins 2.108. 
 
