### PR TITLE
Fix/sonarjnkns 256: Support credentials plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
       <version>1.2.7</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.13</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -401,6 +406,11 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-credentials</artifactId>
         <version>1.13</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>2.1.13</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
@@ -94,7 +94,7 @@ public class MsBuildSQRunnerBegin extends AbstractMsBuildSQRunner {
       addDotNetCommand(args);
     }
     args.add(scannerPath);
-    Map<String, String> props = getSonarProps(sonarInstallation);
+    Map<String, String> props = getSonarProps(sonarInstallation, run);
     addArgsTo(args, sonarInstallation, env, props);
 
     int result = launcher.launch().cmds(args).envs(env).stdout(listener).pwd(BuilderUtils.getModuleRoot(run, workspace)).join();
@@ -104,13 +104,14 @@ public class MsBuildSQRunnerBegin extends AbstractMsBuildSQRunner {
     }
   }
 
-  private static Map<String, String> getSonarProps(SonarInstallation inst) {
+  private static Map<String, String> getSonarProps(SonarInstallation inst, Run<?, ?> run) {
     Map<String, String> map = new LinkedHashMap<>();
 
     map.put("sonar.host.url", inst.getServerUrl());
 
-    if (!StringUtils.isBlank(inst.getServerAuthenticationToken())) {
-      map.put("sonar.login", inst.getServerAuthenticationToken());
+    String token  = inst.getServerAuthenticationToken(run);
+    if (!StringUtils.isBlank(token)) {
+      map.put("sonar.login", token);
     }
 
     return map;

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
@@ -68,7 +68,7 @@ public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
       addDotNetCommand(args);
     }
     args.add(scannerPath);
-    addArgs(args, env, sonarInstallation);
+    addArgs(args, env, sonarInstallation, run);
 
     int result = launcher.launch().cmds(args).envs(env).stdout(listener).pwd(BuilderUtils.getModuleRoot(run, workspace)).join();
 
@@ -80,8 +80,8 @@ public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
     addBadge(run, listener, workspace, sonarInstallation);
   }
 
-  private static void addArgs(ArgumentListBuilder args, EnvVars env, SonarInstallation sonarInstallation) {
-    Map<String, String> props = getSonarProps(sonarInstallation);
+  private static void addArgs(ArgumentListBuilder args, EnvVars env, SonarInstallation sonarInstallation, Run<?, ?> run) {
+    Map<String, String> props = getSonarProps(sonarInstallation, run);
 
     args.add("end");
 
@@ -99,11 +99,12 @@ public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
     args.addTokenized(sonarInstallation.getAdditionalProperties());
   }
 
-  private static Map<String, String> getSonarProps(SonarInstallation inst) {
+  private static Map<String, String> getSonarProps(SonarInstallation inst, Run<?, ?> run) {
     Map<String, String> map = new LinkedHashMap<>();
 
-    if (!StringUtils.isBlank(inst.getServerAuthenticationToken())) {
-      map.put("sonar.login", inst.getServerAuthenticationToken());
+    String token  = inst.getServerAuthenticationToken(run);
+    if (!StringUtils.isBlank(token)) {
+      map.put("sonar.login", token);
     }
 
     return map;

--- a/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
@@ -69,7 +69,7 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
     Logger.LOG.info(msg);
     listener.getLogger().println(msg);
 
-    context.getEnv().putAll(createVars(installation, initialEnvironment));
+    context.getEnv().putAll(createVars(installation, initialEnvironment, build));
 
     context.setDisposer(new AddBuildInfo(installation));
 
@@ -77,13 +77,13 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
   }
 
   @VisibleForTesting
-  static Map<String, String> createVars(SonarInstallation inst, EnvVars initialEnvironment) {
+  static Map<String, String> createVars(SonarInstallation inst, EnvVars initialEnvironment, Run<?, ?> build) {
     Map<String, String> map = new HashMap<>();
 
     map.put("SONAR_CONFIG_NAME", inst.getName());
     String hostUrl = getOrDefault(initialEnvironment.expand(inst.getServerUrl()), "http://localhost:9000");
     map.put("SONAR_HOST_URL", hostUrl);
-    String token = getOrDefault(initialEnvironment.expand(inst.getServerAuthenticationToken()), "");
+    String token = getOrDefault(initialEnvironment.expand(inst.getServerAuthenticationToken(build)), "");
     map.put("SONAR_AUTH_TOKEN", token);
 
     String mojoVersion = inst.getMojoVersion();
@@ -143,8 +143,9 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
 
     List<String> passwords = new ArrayList<>();
 
-    if (!StringUtils.isBlank(inst.getServerAuthenticationToken())) {
-      passwords.add(inst.getServerAuthenticationToken());
+    String token = inst.getServerAuthenticationToken(build);
+    if (!StringUtils.isBlank(token)) {
+      passwords.add(token);
     }
 
     return new SonarQubePasswordLogFilter(passwords, build.getCharset().name());

--- a/src/main/java/hudson/plugins/sonar/SonarGlobalConfiguration.java
+++ b/src/main/java/hudson/plugins/sonar/SonarGlobalConfiguration.java
@@ -19,6 +19,8 @@
  */
 package hudson.plugins.sonar;
 
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.common.*;
 import hudson.CopyOnWrite;
 import hudson.Extension;
 import hudson.ExtensionList;
@@ -26,10 +28,14 @@ import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.plugins.sonar.SonarPublisher.DescriptorImpl;
 import hudson.plugins.sonar.utils.Logger;
+import hudson.security.ACL;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
@@ -118,6 +124,23 @@ public class SonarGlobalConfiguration extends GlobalConfiguration {
 
   public static SonarGlobalConfiguration get() {
     return GlobalConfiguration.all().get(SonarGlobalConfiguration.class);
+  }
+
+  @SuppressWarnings("unused")
+  public ListBoxModel doFillCredentialsIdItems(@QueryParameter String credentialsId) {
+    if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
+      return new StandardListBoxModel().includeCurrentValue(credentialsId);
+    }
+
+    return new StandardListBoxModel()
+      .includeEmptyValue()
+      .includeMatchingAs(
+        ACL.SYSTEM,
+        Jenkins.getInstance(),
+        StandardCredentials.class,
+        Collections.emptyList(),
+        CredentialsMatchers.always()
+      );
   }
 
 }

--- a/src/main/java/hudson/plugins/sonar/SonarInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/SonarInstallation.java
@@ -153,6 +153,12 @@ public class SonarInstallation implements Serializable {
   }
 
   /**
+   * @since X
+   */
+  @SuppressWarnings("unused")
+  public String getCredentialsId() { return credentialsId; }
+
+  /**
    * @return version of sonar-maven-plugin to use
    * @since 1.5
    */

--- a/src/main/java/hudson/plugins/sonar/SonarInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/SonarInstallation.java
@@ -19,7 +19,11 @@
  */
 package hudson.plugins.sonar;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.PasswordCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import hudson.AbortException;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.sonar.model.TriggersConfig;
 import java.io.Serializable;
@@ -37,9 +41,9 @@ public class SonarInstallation implements Serializable {
   private final String serverUrl;
 
   /**
-   * @since 2.4
+   * @since X
    */
-  private String serverAuthenticationToken;
+  private String credentialsId;
 
   /**
    * @since 1.5
@@ -57,12 +61,12 @@ public class SonarInstallation implements Serializable {
 
   @DataBoundConstructor
   public SonarInstallation(String name,
-    String serverUrl, String serverAuthenticationToken,
+    String serverUrl, String credentialsId,
     String mojoVersion, String additionalProperties, TriggersConfig triggers,
     String additionalAnalysisProperties) {
     this.name = name;
     this.serverUrl = serverUrl;
-    this.serverAuthenticationToken = serverAuthenticationToken;
+    this.credentialsId = credentialsId;
     this.additionalAnalysisProperties = additionalAnalysisProperties;
     this.mojoVersion = mojoVersion;
     this.additionalProperties = additionalProperties;
@@ -135,10 +139,13 @@ public class SonarInstallation implements Serializable {
   }
 
   /**
-   * @since 2.4
+   * @since X
    */
-  public String getServerAuthenticationToken() {
-    return StringUtils.trimToNull(serverAuthenticationToken);
+  public String getServerAuthenticationToken(Run<?, ?> build) {
+    if (credentialsId == null) { return null; }
+    StandardCredentials cred = CredentialsProvider.findCredentialById(credentialsId, StandardCredentials.class, build);
+    if (cred == null) { return null; }
+    return ((PasswordCredentials) cred).getPassword().getPlainText();
   }
 
   /**

--- a/src/main/java/hudson/plugins/sonar/SonarInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/SonarInstallation.java
@@ -142,10 +142,14 @@ public class SonarInstallation implements Serializable {
    * @since X
    */
   public String getServerAuthenticationToken(Run<?, ?> build) {
-    if (credentialsId == null) { return null; }
-    StandardCredentials cred = CredentialsProvider.findCredentialById(credentialsId, StandardCredentials.class, build);
+    if (credentialsId == null || build == null) { return null; }
+    StandardCredentials cred = this.getCredentials(build);
     if (cred == null) { return null; }
     return ((PasswordCredentials) cred).getPassword().getPlainText();
+  }
+
+  public StandardCredentials getCredentials(Run<?, ?> build) {
+    return CredentialsProvider.findCredentialById(credentialsId, StandardCredentials.class, build);
   }
 
   /**

--- a/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
+++ b/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
@@ -361,8 +361,9 @@ public class SonarRunnerBuilder extends Builder {
     TaskListener listener, EnvVars env, @Nullable SonarInstallation si) throws IOException, InterruptedException {
     if (si != null) {
       args.append("sonar.host.url", si.getServerUrl());
-      if (StringUtils.isNotBlank(si.getServerAuthenticationToken())) {
-        args.appendMasked("sonar.login", si.getServerAuthenticationToken());
+      String token = si.getServerAuthenticationToken(build);
+      if (StringUtils.isNotBlank(token)) {
+        args.appendMasked("sonar.login", token);
       }
     }
 

--- a/src/main/java/hudson/plugins/sonar/action/SonarCacheAction.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarCacheAction.java
@@ -21,6 +21,7 @@ package hudson.plugins.sonar.action;
 
 import com.google.common.annotations.VisibleForTesting;
 import hudson.model.InvisibleAction;
+import hudson.model.Run;
 import hudson.plugins.sonar.client.ProjectInformation;
 import hudson.plugins.sonar.client.SQProjectResolver;
 import java.util.ArrayList;
@@ -40,7 +41,7 @@ public class SonarCacheAction extends InvisibleAction {
     this.infoByTaskId = new HashMap<>();
   }
 
-  public List<ProjectInformation> get(SQProjectResolver resolver, long lastBuildTime, List<SonarAnalysisAction> analysis) {
+  public List<ProjectInformation> get(SQProjectResolver resolver, long lastBuildTime, List<SonarAnalysisAction> analysis, Run<?, ?> run) {
     if (lastRequest != null && age(lastRequest) < TimeUnit.SECONDS.toMillis(10)) {
       return lastProjInfo;
     }
@@ -48,7 +49,7 @@ public class SonarCacheAction extends InvisibleAction {
     List<ProjectInformation> list = new ArrayList<>(analysis.size());
 
     for (SonarAnalysisAction a : analysis) {
-      ProjectInformation proj = get(resolver, lastBuildTime, a);
+      ProjectInformation proj = get(resolver, lastBuildTime, a, run);
       if (proj != null) {
         list.add(proj);
       }
@@ -61,7 +62,7 @@ public class SonarCacheAction extends InvisibleAction {
 
   @CheckForNull
   @VisibleForTesting
-  ProjectInformation get(SQProjectResolver resolver, long lastBuildTime, SonarAnalysisAction analysis) {
+  ProjectInformation get(SQProjectResolver resolver, long lastBuildTime, SonarAnalysisAction analysis, Run<?, ?> run) {
     String taskId = analysis.getCeTaskId();
 
     if (taskId == null) {
@@ -73,7 +74,7 @@ public class SonarCacheAction extends InvisibleAction {
       return cached;
     }
 
-    ProjectInformation proj = resolver.resolve(analysis.getServerUrl(), analysis.getUrl(), taskId, analysis.getInstallationName());
+    ProjectInformation proj = resolver.resolve(analysis.getServerUrl(), analysis.getUrl(), taskId, analysis.getInstallationName(), run);
     if (proj != null) {
       infoByTaskId.put(taskId, proj);
     }

--- a/src/main/java/hudson/plugins/sonar/action/SonarProjectActionFactory.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarProjectActionFactory.java
@@ -115,7 +115,7 @@ public class SonarProjectActionFactory extends TransientActionFactory<Job> {
 
     synchronized (run) {
       SonarCacheAction cache = getOrCreateCache(run);
-      projects = cache.get(resolver, endTime, actions);
+      projects = cache.get(resolver, endTime, actions, run);
     }
 
     if (projects == null || projects.isEmpty()) {

--- a/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
+++ b/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
@@ -19,6 +19,7 @@
  */
 package hudson.plugins.sonar.client;
 
+import hudson.model.Run;
 import hudson.plugins.sonar.SonarInstallation;
 import hudson.plugins.sonar.client.WsClient.CETask;
 import hudson.plugins.sonar.utils.Logger;
@@ -40,7 +41,7 @@ public class SQProjectResolver {
    * Errors that should be displayed are included in {@link ProjectInformation#getErrors()}.
    */
   @CheckForNull
-  public ProjectInformation resolve(@Nullable String serverUrl, @Nullable String projectDashboardUrl, String ceTaskId, String installationName) {
+  public ProjectInformation resolve(@Nullable String serverUrl, @Nullable String projectDashboardUrl, String ceTaskId, String installationName, Run<?, ?> build) {
     SonarInstallation inst = SonarInstallation.get(installationName);
     if (inst == null) {
       Logger.LOG.info(() -> "Invalid installation name: " + installationName);
@@ -53,7 +54,7 @@ public class SQProjectResolver {
 
     try {
 
-      WsClient wsClient = new WsClient(client, serverUrl, inst.getServerAuthenticationToken());
+      WsClient wsClient = new WsClient(client, serverUrl, inst.getServerAuthenticationToken(build));
       Version version = new Version(wsClient.getServerVersion());
 
       if (version.compareTo(new Version("5.6")) < 0) {

--- a/src/main/java/hudson/plugins/sonar/utils/SonarMaven.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarMaven.java
@@ -95,8 +95,9 @@ public final class SonarMaven extends Maven {
 
     argsBuilder.append("sonar.branch", publisher.getBranch());
 
-    if (StringUtils.isNotBlank(getInstallation().getServerAuthenticationToken())) {
-      argsBuilder.appendMasked("sonar.login", getInstallation().getServerAuthenticationToken());
+    String token = getInstallation().getServerAuthenticationToken(build);
+    if (StringUtils.isNotBlank(token)) {
+      argsBuilder.appendMasked("sonar.login", token);
     }
 
     if (build instanceof MavenModuleSetBuild) {

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
@@ -174,7 +174,7 @@ public class WaitForQualityGateStep extends Step implements Serializable {
 
       log("Checking status of SonarQube task '%s' on server '%s'", step.taskId, step.getInstallationName());
 
-      WsClient wsClient = new WsClient(new HttpClient(), step.getServerUrl(), inst.getServerAuthenticationToken());
+      WsClient wsClient = new WsClient(new HttpClient(), step.getServerUrl(), inst.getServerAuthenticationToken(getContext().get(Run.class)));
       WsClient.CETask ceTask = wsClient.getCETask(step.getTaskId());
       log("SonarQube task '%s' status is '%s'", step.taskId, ceTask.getStatus());
       switch (ceTask.getStatus()) {

--- a/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
          
   <script type="text/javascript" src="${rootURL}/plugin/sonar/js/global_config.js" />
   
@@ -20,9 +20,9 @@
           <f:entry title="${%ServerUrl}" description="${%ServerUrlDescr}">
             <f:textbox name="sonar.serverUrl" value="${inst.getServerUrl()}"/>
           </f:entry>
-                    
-          <f:entry title="${%ServerToken}" description="${%ServerTokenDescr}">
-            <f:password name="sonar.serverAuthenticationToken" value="${inst.getServerAuthenticationToken()}"/>
+
+          <f:entry title="${%ServerToken}" field="credentialsId">
+            <c:select value="${inst.getCredentialsId()}"/>
           </f:entry>
 
           <f:advanced>

--- a/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerBeginTest.java
+++ b/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerBeginTest.java
@@ -31,6 +31,10 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class MsBuildSQRunnerBeginTest extends MsBuildSQRunnerTest {
 
@@ -89,8 +93,9 @@ public class MsBuildSQRunnerBeginTest extends MsBuildSQRunnerTest {
 
   @Test
   public void testSonarProps() throws Exception {
-    SonarInstallation inst = new SonarInstallation("default", "http://dummy-server:9090", "token",
-      null, null, null, null);
+    SonarInstallation inst = spy(new SonarInstallation("default", "http://dummy-server:9090", "credentialsId",
+      null, null, null, null));
+    when(inst.getServerAuthenticationToken(any(Run.class))).thenReturn("token");
     configureSonar(inst);
     configureMsBuildScanner(false);
 

--- a/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerEndTest.java
+++ b/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerEndTest.java
@@ -27,12 +27,17 @@ import hudson.plugins.sonar.MsBuildSQRunnerEnd.DescriptorImpl;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class MsBuildSQRunnerEndTest extends MsBuildSQRunnerTest {
 
   @Test
   public void testToken() throws Exception {
-    configureSonar(new SonarInstallation(SONAR_INSTALLATION_NAME, "localhost", "token", null, null, null, null));
+    SonarInstallation inst = spy(new SonarInstallation(SONAR_INSTALLATION_NAME, "localhost", "credentialsId", null, null, null, null));
+    when(inst.getServerAuthenticationToken(any(Run.class))).thenReturn("token");
+    configureSonar(inst);
     configureMsBuildScanner(false);
 
     FreeStyleProject proj = setupFreeStyleProject(new MsBuildSQRunnerBegin("default", "default", "key", "name", "1.0", ""));

--- a/src/test/java/hudson/plugins/sonar/SonarRunnerBuilderTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarRunnerBuilderTest.java
@@ -26,6 +26,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Node;
+import hudson.model.Run;
 import hudson.plugins.sonar.utils.ExtendedArgumentListBuilder;
 import hudson.scm.SCM;
 import hudson.util.ArgumentListBuilder;
@@ -130,7 +131,7 @@ public class SonarRunnerBuilderTest extends SonarTestCase {
   public void shouldPopulateSonarToken() throws IOException, InterruptedException {
     SonarInstallation installation = mock(SonarInstallation.class);
     when(installation.getServerUrl()).thenReturn("hostUrl");
-    when(installation.getServerAuthenticationToken()).thenReturn("token");
+    when(installation.getServerAuthenticationToken(any(Run.class))).thenReturn("token");
 
     SonarRunnerBuilder builder = new SonarRunnerBuilder(null, null, null, null, null, null, null, null);
     builder.populateConfiguration(argsBuilder, build, build.getWorkspace(), listener, env, installation);

--- a/src/test/java/hudson/plugins/sonar/utils/SonarMavenTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/SonarMavenTest.java
@@ -23,6 +23,7 @@ import hudson.Launcher;
 import hudson.maven.local_repo.DefaultLocalRepositoryLocator;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
+import hudson.model.Run;
 import hudson.plugins.sonar.SonarInstallation;
 import hudson.plugins.sonar.SonarPublisher;
 import hudson.util.ArgumentListBuilder;
@@ -32,6 +33,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,7 +47,7 @@ public class SonarMavenTest {
     SonarPublisher publisher = mock(SonarPublisher.class);
     SonarInstallation installation = mock(SonarInstallation.class);
     when(installation.getServerUrl()).thenReturn("hostUrl");
-    when(installation.getServerAuthenticationToken()).thenReturn("xyz");
+    when(installation.getServerAuthenticationToken(any(Run.class))).thenReturn("xyz");
     when(publisher.getInstallation()).thenReturn(installation);
     when(publisher.getBranch()).thenReturn("branch");
 


### PR DESCRIPTION
This fixes the [SONARJNKNS-256](https://jira.sonarsource.com/browse/SONARJNKNS-256). We use the Jenkins credentials plugin instead of saving the token directly inside the xml file. The tests are extended, updated and running. A manually created `hpi` file works as expected.

The changes are not compatible to the previous version, since the former `serverAuthenticationToken` gets removed completely. Is there a way to provide a migration strategy? We think, creating credentials automatically is not a proper way to handle that.

![image](https://user-images.githubusercontent.com/1176296/42516044-781e9c1a-845d-11e8-85e7-c0c5113e46f5.png)

`hudson.plugins.sonar.SonarGlobalConfiguration.xml`:
```xml
<?xml version='1.0' encoding='UTF-8'?>
<hudson.plugins.sonar.SonarGlobalConfiguration plugin="sonar@2.X">
  <installations>
    <hudson.plugins.sonar.SonarInstallation>
      <name>SonarQube Server</name>
      <serverUrl></serverUrl>
      <credentialsId>sonarqube_token</credentialsId>
....
```

What's your opinion on these changes? Do you want us to change something? We are already using it and it works exactly the way we want.