### PR TITLE
Do not fail pipeline on WARN status

### DIFF
--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
@@ -197,7 +197,7 @@ public class WaitForQualityGateStep extends Step implements Serializable {
     }
 
     private void handleQGStatus(String status) {
-      if (step.isAbortPipeline() && !"OK".equals(status)) {
+      if (step.isAbortPipeline() && !"OK".equals(status) && !"WARN".equals(status)) {
         getContext().onFailure(new AbortException("Pipeline aborted due to quality gate failure: " + status));
       } else {
         getContext().onSuccess(new QGStatus(status));


### PR DESCRIPTION
I created a PR over here https://github.com/jenkinsci/sonarqube-plugin/pull/2, but maybe you guys only look at PRs on this repo, so I am creating it here as well just to see if I get replies :)

I have used old versions of SonarQube before the quality gate status was async, and I remember that the Gradle task to perform analysis was capable of failing the build on a FAILED quality gate.
But on that case, if I am not mistaken, a WARN quality gate would **NOT** fail the build.

I upgraded sonar and switched to new pipeline and now the build fails on WARN as well.

Would you not agree to pass the build on OK and WARN and only fail on ERROR and NONE?
**This current PR proposes to pass a build on WARN.**

In any case, we could make this setting configurable. Instead of boolean `abortPipeline`, we could say:

`waitForQualityGate abortOnStatuses: ["ERROR", "NONE"]`

Or

`waitForQualityGate passOnStatuses: ["OK", "WARN"]`

Or some other type of configuration.

To keep backwards compatible I think this can be done:

```
  @DataBoundConstructor
  public WaitForQualityGateStep() {
    this.abortPipeline = false;
    this.passOnStatuses.add("OK");
  }

  @DataBoundSetter
  public void setPassOnStatuses(List<String> passOnStatuses) {
    this.abortPipeline = true;
    this.passOnStatuses = passOnStatuses;
  }

  @Deprecated
  @DataBoundSetter
  public void setAbortPipeline(boolean abortPipeline) {
    this.abortPipeline = abortPipeline;
  }
```

Let me know what you think.

Thanks.