### PR TITLE
Upgrade jaCoCo version to 0.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.6.201602180812</version>
+          <version>0.8.2</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Hello,

My team and I use your plugin in a Jenkins jobs for our project which was builded with JDK9 and now 10. 

```
WARN: Exception during analysis of file /var/lib/jenkins/workspace/Sidomi/Sidomi - Recette/common/target/classes/com/domiserve/sidomi/config/LogFileAppender.class
18:00:55 java.io.IOException: Error while analyzing class /var/lib/jenkins/workspace/Sidomi/Sidomi - Recette/common/target/classes/com/domiserve/sidomi/config/LogFileAppender.class.
18:00:55 	at org.jacoco.core.analysis.Analyzer.analyzerError(Analyzer.java:150)
18:00:55 	at org.jacoco.core.analysis.Analyzer.analyzeClass(Analyzer.java:144)
18:00:55 	at org.sonar.plugins.jacoco.JacocoReportReader.analyzeClassFile(JacocoReportReader.java:139)
```


```
18:00:58 Caused by: java.lang.IllegalArgumentException: null
18:00:58 	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:170)
18:00:58 	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:153)
18:00:58 	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:424)
18:00:58 	at org.jacoco.core.analysis.Analyzer.analyzeClass(Analyzer.java:142)
```

This happens when there is those properties in sonar.properties

```
# Jacoco (Code coverage) reports
#sonar.java.coveragePlugin=jacoco
#sonar.jacoco.reportPaths=api/target/jacoco.exec
```

Since this error did not disappear after updating your plugin I decided to dive in the code.

In fact JaCoCo use Asm to read class's bytecodes

JaCoCO Release : https://github.com/jacoco/jacoco/releases
JaCoCo 0.8.0 : now officially supports Java 9 (GitHub #600).
JaCoCO 0.8.1 : now supports Java 10 (GitHub #629).
There is also experimental support of Java 11 and 12 in the 0.8.2 version.

This upgrade is a fix for this warning, and hopefully will fix the coverage in our Sonarqube Server.