### PR TITLE
Make Jenkins call the SQ URL defined in the SonarInstallation

### DIFF
--- a/its/src/test/java/com/sonar/it/jenkins/JenkinsTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/JenkinsTest.java
@@ -38,6 +38,9 @@ import static org.fest.assertions.Assertions.assertThat;
 
 public class JenkinsTest {
 
+  // Jenkins should only talk to the URL actually configured in a SonarInstallation
+  final static String SONAR_PUBLIC_BASE_URL = "http://sonar_public_domain/";
+
   @ClassRule
   public static Orchestrator orchestrator = JenkinsTestSuite.ORCHESTRATOR;
 
@@ -47,7 +50,7 @@ public class JenkinsTest {
   @BeforeClass
   public static void setUpSonar() {
     // Workaround for SONAR-4257
-    orchestrator.getServer().getAdminWsClient().update(new PropertyUpdateQuery("sonar.core.serverBaseURL", orchestrator.getServer().getUrl()));
+    orchestrator.getServer().getAdminWsClient().update(new PropertyUpdateQuery("sonar.core.serverBaseURL", SONAR_PUBLIC_BASE_URL));
   }
 
   @BeforeClass
@@ -87,6 +90,7 @@ public class JenkinsTest {
     waitForComputationOnSQServer();
     assertThat(getProject(projectKey)).isNotNull();
     assertSonarUrlOnJob(jobName, projectKey);
+    jenkins.assertQGOnProjectPage(jobName);
   }
 
   @Test
@@ -100,6 +104,7 @@ public class JenkinsTest {
     waitForComputationOnSQServer();
     assertThat(getProject(projectKey)).isNotNull();
     assertSonarUrlOnJob(jobName, projectKey);
+    jenkins.assertQGOnProjectPage(jobName);
   }
 
   @Test
@@ -188,12 +193,12 @@ public class JenkinsTest {
   }
 
   private void assertSonarUrlOnJob(String jobName, String projectKey) {
-    assertThat(jenkins.getSonarUrlOnJob(jobName)).startsWith(orchestrator.getServer().getUrl());
     if (jenkins.getServer().getVersion().isGreaterThanOrEquals(2, 0)) {
       assertThat(jenkins.getSonarUrlOnJob(jobName)).endsWith(URLEncoder.encode(projectKey));
     } else {
       assertThat(jenkins.getSonarUrlOnJob(jobName)).endsWith(projectKey);
     }
+    assertThat(jenkins.getSonarUrlOnJob(jobName)).startsWith(SONAR_PUBLIC_BASE_URL);
   }
 
   private static void waitForComputationOnSQServer() {

--- a/its/src/test/java/com/sonar/it/jenkins/JenkinsWithoutMaven.java
+++ b/its/src/test/java/com/sonar/it/jenkins/JenkinsWithoutMaven.java
@@ -39,6 +39,10 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
 
 public class JenkinsWithoutMaven {
+
+  // Jenkins should only talk to the URL actually configured in a SonarInstallation
+  final static String SONAR_PUBLIC_BASE_URL = "http://sonar_public_domain/";
+
   @ClassRule
   public static Orchestrator orchestrator = JenkinsTestSuite.ORCHESTRATOR;
 
@@ -53,7 +57,7 @@ public class JenkinsWithoutMaven {
   @BeforeClass
   public static void setUpSonar() {
     // Workaround for SONAR-4257
-    orchestrator.getServer().getAdminWsClient().update(new PropertyUpdateQuery("sonar.core.serverBaseURL", orchestrator.getServer().getUrl()));
+    orchestrator.getServer().getAdminWsClient().update(new PropertyUpdateQuery("sonar.core.serverBaseURL", SONAR_PUBLIC_BASE_URL));
   }
 
   @BeforeClass
@@ -182,7 +186,7 @@ public class JenkinsWithoutMaven {
   }
 
   private void assertSonarUrlOnJob(String jobName, String projectKey) {
-    assertThat(jenkins.getSonarUrlOnJob(jobName)).startsWith(orchestrator.getServer().getUrl());
+    assertThat(jenkins.getSonarUrlOnJob(jobName)).startsWith(SONAR_PUBLIC_BASE_URL);
     assertThat(jenkins.getSonarUrlOnJob(jobName)).endsWith(projectKey);
   }
 

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
@@ -73,11 +73,11 @@ public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
     int result = launcher.launch().cmds(args).envs(env).stdout(listener).pwd(BuilderUtils.getModuleRoot(run, workspace)).join();
 
     if (result != 0) {
-      addBadge(run, listener, workspace, sonarInstallation);
+      addBadge(run, listener, workspace, sonarInstallation, env);
       throw new AbortException(Messages.MSBuildScanner_ExecFailed(result));
     }
 
-    addBadge(run, listener, workspace, sonarInstallation);
+    addBadge(run, listener, workspace, sonarInstallation, env);
   }
 
   private static void addArgs(ArgumentListBuilder args, EnvVars env, SonarInstallation sonarInstallation) {
@@ -109,8 +109,8 @@ public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
     return map;
   }
 
-  private static void addBadge(Run<?, ?> run, TaskListener listener, FilePath workspace, SonarInstallation sonarInstallation) throws IOException, InterruptedException {
-    SonarUtils.addBuildInfoTo(run, listener, workspace, sonarInstallation.getName());
+  private static void addBadge(Run<?, ?> run, TaskListener listener, FilePath workspace, SonarInstallation sonarInstallation, EnvVars env) throws IOException, InterruptedException {
+    SonarUtils.addBuildInfoTo(run, listener, workspace, sonarInstallation.getName(), env.expand(sonarInstallation.getServerUrl()));
   }
 
   @Override

--- a/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
@@ -71,7 +71,7 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
 
     context.getEnv().putAll(createVars(installation, initialEnvironment));
 
-    context.setDisposer(new AddBuildInfo(installation));
+    context.setDisposer(new AddBuildInfo(installation, context.getEnv().get("SONAR_HOST_URL")));
 
     build.addAction(new SonarMarkerAction());
   }
@@ -155,15 +155,17 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
     private static final long serialVersionUID = 1L;
 
     private final SonarInstallation installation;
+    private final String sonarHostUrl;
 
-    public AddBuildInfo(SonarInstallation installation) {
+    public AddBuildInfo(SonarInstallation installation, String sonarHostUrl) {
       this.installation = installation;
+      this.sonarHostUrl = sonarHostUrl;
     }
 
     @Override
     public void tearDown(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
       // null result means success so far. If no logs are found, it's probably because it was simply skipped
-      SonarUtils.addBuildInfoTo(build, listener, workspace, installation.getName(), build.getResult() == null);
+      SonarUtils.addBuildInfoTo(build, listener, workspace, installation.getName(), sonarHostUrl, build.getResult() == null);
     }
   }
 

--- a/src/main/java/hudson/plugins/sonar/action/SonarCacheAction.java
+++ b/src/main/java/hudson/plugins/sonar/action/SonarCacheAction.java
@@ -73,7 +73,7 @@ public class SonarCacheAction extends InvisibleAction {
       return cached;
     }
 
-    ProjectInformation proj = resolver.resolve(analysis.getServerUrl(), analysis.getUrl(), taskId, analysis.getInstallationName());
+    ProjectInformation proj = resolver.resolve(analysis.getUsableServerUrl(), analysis.getUrl(), taskId, analysis.getInstallationName());
     if (proj != null) {
       infoByTaskId.put(taskId, proj);
     }

--- a/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
@@ -100,14 +100,13 @@ public final class SonarUtils {
 
   }
 
-  @Nullable
   /** 
    * Collects as much information as it finds from the sonar analysis in the build and adds it as an action to the build.
    * Even if no information is found, the action is added, marking in the build that a sonar analysis ran. 
    */
-  public static SonarAnalysisAction addBuildInfoTo(Run<?, ?> build, TaskListener listener, FilePath workspace, String installationName, boolean skippedIfNoBuild)
+  public static SonarAnalysisAction addBuildInfoTo(Run<?, ?> build, TaskListener listener, FilePath workspace, String installationName, @Nullable String sonarHostUrl, boolean skippedIfNoBuild)
     throws IOException, InterruptedException {
-    SonarAnalysisAction buildInfo = new SonarAnalysisAction(installationName);
+    SonarAnalysisAction buildInfo = new SonarAnalysisAction(installationName, sonarHostUrl);
     Properties reportTask = extractReportTask(listener, workspace);
 
     if (reportTask != null) {
@@ -122,8 +121,13 @@ public final class SonarUtils {
     return buildInfo;
   }
 
+  public static SonarAnalysisAction addBuildInfoTo(Run<?, ?> build, TaskListener listener, FilePath workspace, String installationName, @Nullable String sonarHostUrl)
+      throws IOException, InterruptedException {
+    return addBuildInfoTo(build, listener, workspace, installationName, sonarHostUrl, false);
+  }
+
   public static SonarAnalysisAction addBuildInfoTo(Run<?, ?> build, TaskListener listener, FilePath workspace, String installationName) throws IOException, InterruptedException {
-    return addBuildInfoTo(build, listener, workspace, installationName, false);
+    return addBuildInfoTo(build, listener, workspace, installationName, null);
   }
 
   public static SonarAnalysisAction addBuildInfoFromLastBuildTo(Run<?, ?> build, String installationName, boolean isSkipped) {

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
@@ -150,7 +150,7 @@ public class WaitForQualityGateStep extends Step implements Serializable {
       for (SonarAnalysisAction a : reversedActions) {
         ceTaskId = a.getCeTaskId();
         if (ceTaskId != null) {
-          serverUrl = a.getServerUrl();
+          serverUrl = a.getUsableServerUrl();
           installationName = a.getInstallationName();
           break;
         }

--- a/src/test/java/hudson/plugins/sonar/action/SonarCacheActionTest.java
+++ b/src/test/java/hudson/plugins/sonar/action/SonarCacheActionTest.java
@@ -74,6 +74,32 @@ public class SonarCacheActionTest {
   }
 
   @Test
+  public void testResolveViaInternalUrl() {
+    SonarAnalysisAction analysis = new SonarAnalysisAction("inst");
+    analysis.setCeTaskId("taskId");
+    analysis.setUrl("projUrl");
+    analysis.setServerUrl("publicServerUrl");
+    analysis.setInstallationServerUrl("serverUrl");
+    analysis.setUrl("projUrl");
+
+    cache.get(resolver, 0, Collections.singletonList(analysis));
+    verify(resolver).resolve("serverUrl", "projUrl", "taskId", "inst");
+  }
+
+  @Test
+  public void testResolveViaPublicUrlWhenInternalUrlIsNotExpanded() {
+    SonarAnalysisAction analysis = new SonarAnalysisAction("inst");
+    analysis.setCeTaskId("taskId");
+    analysis.setUrl("projUrl");
+    analysis.setServerUrl("publicServerUrl");
+    analysis.setInstallationServerUrl("${serverUrl}");
+    analysis.setUrl("projUrl");
+
+    cache.get(resolver, 0, Collections.singletonList(analysis));
+    verify(resolver).resolve("publicServerUrl", "projUrl", "taskId", "inst");
+  }
+
+  @Test
   public void testResponseCached() {
     ProjectInformation mocked = createProj(now(), "success");
     SonarAnalysisAction analysis = createAnalysis("serverUrl", "projUrl", "taskId");

--- a/src/test/java/hudson/plugins/sonar/client/SQProjectResolverTest.java
+++ b/src/test/java/hudson/plugins/sonar/client/SQProjectResolverTest.java
@@ -43,8 +43,9 @@ import static org.mockito.Mockito.when;
 
 public class SQProjectResolverTest extends SonarTestCase {
   private final static String SERVER_URL = "http://localhost:9000";
+  private final static String PUBLIC_SERVER_URL = "http://whatever";
   private final static String PROJECT_KEY = "org.sonarsource.sonarlint:sonarlint-cli";
-  private final static String PROJECT_URL = SERVER_URL + "/dashboard/index/" + PROJECT_KEY;
+  private final static String PROJECT_URL = PUBLIC_SERVER_URL + "/dashboard/index/" + PROJECT_KEY;
   private final static String CE_TASK_ID = "task1";
   private final static String PASS = "mypass";
   private final static String USER = "user";

--- a/src/test/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStepTest.java
+++ b/src/test/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStepTest.java
@@ -302,10 +302,10 @@ public class WaitForQualityGateStepTest {
       .setInstallations(
         new SonarInstallation(SONAR_INSTALLATION_NAME, serverUrl, null, null, null, null, null));
     WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, JOB_NAME);
-    String reportTaskContent1 = "dashboardUrl=" + serverUrl + "/dashboard\\n"
-      + "ceTaskId=" + FAKE_TASK_ID_1 + "\\nserverUrl=" + serverUrl + "\\nprojectKey=foo";
-    String reportTaskContent2 = "dashboardUrl=" + serverUrl + "/dashboard\\n"
-      + "ceTaskId=" + FAKE_TASK_ID_2 + "\\nserverUrl=" + serverUrl + "\\nprojectKey=foo";
+    String reportTaskContent1 = "dashboardUrl=http://whatever/sonarqube/dashboard\\n"
+        + "ceTaskId=" + FAKE_TASK_ID_1 + "\\nserverUrl=http://whatever/sonarqube\\nprojectKey=foo";
+    String reportTaskContent2 = "dashboardUrl=http://whatever/sonarqube/dashboard\\n"
+        + "ceTaskId=" + FAKE_TASK_ID_2 + "\\nserverUrl=http://whatever/sonarqube\\nprojectKey=foo";
     p.setDefinition(new CpsFlowDefinition(
       script(reportTaskContent1, reportTaskContent2, specifyServer, twoProjects),
       true));


### PR DESCRIPTION
Make Jenkins call the SQ URL defined in the SonarInstallation, instead of SQ public URL.

see https://community.sonarsource.com/t/sonarjnks-2-8-jenkins-plugin-calls-public-sonarqube-url-instead-of-the-one-set-in-sonarinstallation/2776?u=thomasgl-orange

To make this work with the corner-case requirements from SONARJNKNS-287 (server URL defined via some variables), we store the expanded URL in SonarAnalysisAction.

Note that vars expansion for the URL is not implemented in SonarPublisher/SonarMaven (would be possible, but it's deprecated code, so we keep its old behavior unchanged).