### PR TITLE
Fix IOException if the workspace doesn't exist

### DIFF
--- a/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
@@ -84,8 +84,11 @@ public final class SonarUtils {
   }
 
   public static Properties extractReportTask(TaskListener listener, FilePath workspace) throws IOException, InterruptedException {
-    FilePath[] candidates = workspace.list("**/" + REPORT_TASK_FILE_NAME);
-    if (candidates.length == 0) {
+    FilePath[] candidates = null;
+    if (workspace.exists()) {
+      candidates = workspace.list("**/" + REPORT_TASK_FILE_NAME);
+    }
+    if (candidatest == null || candidates.length == 0) {
       listener.getLogger().println("WARN: Unable to locate '" + REPORT_TASK_FILE_NAME + "' in the workspace. Did the SonarScanner succeeded?");
       return null;
     } else {


### PR DESCRIPTION
Check if the workspace exists before trying to search `REPORT_TASK_FILE_NAME` in it. If the workspace didn't exist, the following Exception was thrown:

```
Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to JNLP4-connect connection from ***************
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1743)
		at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:357)
		at hudson.remoting.Channel.call(Channel.java:957)
		at hudson.FilePath.act(FilePath.java:1069)
		at hudson.FilePath.act(FilePath.java:1058)
		at hudson.FilePath.list(FilePath.java:1892)
		at hudson.FilePath.list(FilePath.java:1876)
		at hudson.FilePath.list(FilePath.java:1861)
		at hudson.plugins.sonar.utils.SonarUtils.extractReportTask(SonarUtils.java:84)
		at hudson.plugins.sonar.utils.SonarUtils.addBuildInfoTo(SonarUtils.java:111)
		at hudson.plugins.sonar.SonarBuildWrapper$AddBuildInfo.tearDown(SonarBuildWrapper.java:170)
		at org.jenkinsci.plugins.workflow.steps.CoreWrapperStep$Callback.finished(CoreWrapperStep.java:152)
		at org.jenkinsci.plugins.workflow.steps.CoreWrapperStep$Execution2$Callback2.finished(CoreWrapperStep.java:122)
		at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution$TailCall.lambda$onSuccess$0(GeneralNonBlockingStepExecution.java:140)
		at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution.lambda$run$0(GeneralNonBlockingStepExecution.java:77)
		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
		at java.util.concurrent.FutureTask.run(FutureTask.java:266)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
java.io.IOException: /PATH/TO/WORKSPACE does not exist.
	at hudson.FilePath.glob(FilePath.java:1932)
	at hudson.FilePath.access$3200(FilePath.java:210)
	at hudson.FilePath$ListGlob.invoke(FilePath.java:1906)
	at hudson.FilePath$ListGlob.invoke(FilePath.java:1894)
	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3042)
	at hudson.remoting.UserRequest.perform(UserRequest.java:212)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:369)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:93)
	at java.lang.Thread.run(Thread.java:748)

```