### PR TITLE
drop empty tokens when migrating to credentials

### DIFF
--- a/src/main/java/hudson/plugins/sonar/SonarInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/SonarInstallation.java
@@ -246,8 +246,10 @@ public class SonarInstallation implements Serializable {
 
   @SuppressWarnings("deprecation")
   void migrateTokenToCredential() {
-    if (this.serverAuthenticationToken != null && Util.fixEmpty(this.serverAuthenticationToken.getPlainText()) != null) {
-      this.credentialsId = new GlobalCredentialMigrator().migrate(this.serverAuthenticationToken.getPlainText()).getId();
+    if (this.serverAuthenticationToken != null) {
+      if (Util.fixEmpty(this.serverAuthenticationToken.getPlainText()) != null) {
+        this.credentialsId = new GlobalCredentialMigrator().migrate(this.serverAuthenticationToken.getPlainText()).getId();
+      }
       this.serverAuthenticationToken = null;
     }
   }


### PR DESCRIPTION
When migrating from 2.8.x to 2.9, on credentials migration, empty authentication tokens in `SonarInstallation`s are ignored, and will persist in the `hudson.plugins.sonar.SonarGlobalConfiguration.xml` (the `<serverAuthenticationToken>...</serverAuthenticationToken>` is kept as-is). It should have been nullified instead, because the semantics of such configuration is "no authentification token needed".