### PR TITLE
Allow setting a custom cache directory for SonarScanner

### DIFF
--- a/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
+++ b/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
@@ -67,6 +67,7 @@ public class SonarRunnerBuilder extends Builder {
   private String properties;
   private String javaOpts;
   private String additionalArguments;
+  private String sonarHome;
 
   /**
    * Identifies {@link JDK} to be used.
@@ -207,6 +208,15 @@ public class SonarRunnerBuilder extends Builder {
     this.additionalArguments = additionalArguments;
   }
 
+  public String getSonarHome() {
+    return Util.fixNull(sonarHome);
+  }
+
+  @DataBoundSetter
+  public void setSonarHome(String sonarHome) {
+    this.sonarHome = sonarHome;
+  }
+
   public SonarInstallation getSonarInstallation() {
     return SonarInstallation.get(getInstallationName());
   }
@@ -286,6 +296,10 @@ public class SonarRunnerBuilder extends Builder {
     env.put("SONAR_SCANNER_OPTS", getJavaOpts());
     // For backward compatibility with old sonar-runner
     env.put("SONAR_RUNNER_OPTS", getJavaOpts());
+
+    if (!StringUtils.isEmpty(sonarHome)) {
+      env.put("SONAR_USER_HOME", getSonarHome());
+    }
 
     long startTime = System.currentTimeMillis();
     int exitCode;

--- a/src/main/resources/hudson/plugins/sonar/SonarRunnerBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarRunnerBuilder/config.jelly
@@ -73,7 +73,10 @@
   <f:entry title="${%AdditionalArguments}" field="additionalArguments" help="/plugin/sonar/help-runner-additional-args.html">
     <f:expandableTextbox />
   </f:entry>
-  
+
+  <f:entry title="${%SonarHome}" field="sonarHome" help="/plugin/sonar/help-runner-sonar-home.html">
+    <f:textbox />
+  </f:entry>
 
   <!-- The Java options to be used -->
   <f:entry title="${%JVMOptions}" field="javaOpts" help="/plugin/sonar/help-runner-jvm-opts.html">

--- a/src/main/resources/hudson/plugins/sonar/SonarRunnerBuilder/config.properties
+++ b/src/main/resources/hudson/plugins/sonar/SonarRunnerBuilder/config.properties
@@ -12,3 +12,4 @@ Sonar\ Scanner\ Version.error.2=Please do so from the <a href="{0}" target="_new
 Sonar\ Scanner\ Version.error.2.beforeV2=Please do so from the <a href="{0}" target="_new">system configuration</a>.
 Task=Task to run
 AdditionalArguments=Additional arguments
+SonarHome=SonarQube home directory

--- a/src/main/webapp/help-runner-sonar-home.html
+++ b/src/main/webapp/help-runner-sonar-home.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    Optional.<br/>
+    The directory where SonarQube will cache various things like plugins.
+  </p>
+</div>


### PR DESCRIPTION
When running multiple SonarQube Scanners with different versions from a single Jenkins instance against different versions of SonarQube, the cache directory conflicts. This PR allows setting custom cache directories such as $WORKSPACE/.sonar-cache-1 and $WORKSPACE/.sonar-cache-2.