### PR TITLE
Fixed the OKHttp3 conflicts with Jenkins lts, which still uses okhttp2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,13 @@
 
     <plugins>
       <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+            <pluginFirstClassLoader>true</pluginFirstClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
It seems the okhttp3 lib used by sonarsource plugin upgraded since 2.9, which causes conflicts with the one used by Jenkins. This occasionally causes method not found exceptions. 

It can be fixed by loading the sonarsource classes first.