### PR TITLE
SONARJNKNS-319 Do not persist supplyJenkins field to xml config of pl…

### DIFF
--- a/src/main/java/hudson/plugins/sonar/SonarGlobalConfiguration.java
+++ b/src/main/java/hudson/plugins/sonar/SonarGlobalConfiguration.java
@@ -32,6 +32,7 @@ import hudson.plugins.sonar.utils.Logger;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import java.io.Serializable;
 import java.util.function.Supplier;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
@@ -52,9 +53,9 @@ import java.util.Optional;
  * The global configuration was migrated from SonarPublisher to this component.
  */
 @Extension(ordinal = 100)
-public class SonarGlobalConfiguration extends GlobalConfiguration {
+public class SonarGlobalConfiguration extends GlobalConfiguration implements Serializable {
 
-  private final Supplier<Jenkins> jenkinsSupplier;
+  private final transient Supplier<Jenkins> supplyJenkins;
 
   @CopyOnWrite
   private volatile SonarInstallation[] installations = new SonarInstallation[0];
@@ -72,7 +73,7 @@ public class SonarGlobalConfiguration extends GlobalConfiguration {
   @VisibleForTesting
   public SonarGlobalConfiguration(Supplier<Jenkins> supplier) {
     load();
-    this.jenkinsSupplier = supplier;
+    this.supplyJenkins = supplier;
   }
 
   /**
@@ -168,7 +169,7 @@ public class SonarGlobalConfiguration extends GlobalConfiguration {
   }
 
   private ListBoxModel createListBoxModel(String credentialId) {
-    if (!jenkinsSupplier.get().hasPermission(Jenkins.ADMINISTER)) {
+    if (!supplyJenkins.get().hasPermission(Jenkins.ADMINISTER)) {
       return new StandardListBoxModel().includeCurrentValue(credentialId);
     }
 
@@ -176,7 +177,7 @@ public class SonarGlobalConfiguration extends GlobalConfiguration {
       .includeEmptyValue()
       .includeMatchingAs(
         ACL.SYSTEM,
-        jenkinsSupplier.get(),
+        supplyJenkins.get(),
         StringCredentials.class,
         Collections.emptyList(),
         CredentialsMatchers.always()


### PR DESCRIPTION
This PR fixes the issue expressed in [this community thread](https://community.sonarsource.com/t/sonar-jenkins-plugin-v2-10-triggering-invalid-data-format-warning-in-jenkins-on-boot/18601) and on [GH](https://github.com/SonarSource/sonar-scanner-jenkins/commit/2e64558c06e37ab5d5286b327ac566cc8beafcfd).

It can be tested by running a docker container with Jenkins installed (see `develop.md`).
The following steps can be followed:

1. Install the sonar-plugin with a version before this fix (revision d9ee458).
2. Add a configuration entry by going to *Manage Jenkins > Configure System > Add a SonarQube Server*
3. Restart Jenkins by going to http://localhost:8080/restart
4. Verify that there is a warning showed when going to *Manage Jenkins* (this is the bug reported)
5. Uninstall the plugin & install the plugin that includes this fix
6. Restart Jenkins by going to http://localhost:8080/restart
7. Verify that there is a warning showed when going to *Manage Jenkins* and that you can delete the wrong data
8. Verify that it is not possible to receive another warning by changing the SonarQube Server config
