### PR TITLE
Rename Quality Gate status in Jenkins job page

### DIFF
--- a/src/main/java/hudson/plugins/sonar/client/ProjectInformation.java
+++ b/src/main/java/hudson/plugins/sonar/client/ProjectInformation.java
@@ -33,6 +33,10 @@ public class ProjectInformation extends InvisibleAction {
   private String ceStatus;
   private String ceUrl;
 
+  private final String ERROR_MESSAGE = "Failed";
+  private final String OK_MESSAGE = "Passed";
+  private final String WARN_MESSAGE = "Warning";
+
   public ProjectInformation() {
     this.created = System.currentTimeMillis();
   }
@@ -93,6 +97,25 @@ public class ProjectInformation extends InvisibleAction {
 
   public void setStatus(String status) {
     this.status = status;
+  }
+
+  public String getBadgeStatus() {
+
+    String badgeString = "";
+
+    if (status == null) {
+      return "N/A";
+    }
+
+    switch(status.toUpperCase()) {
+      case "OK": 
+        badgeString = OK_MESSAGE;
+      case "WARN": 
+        badgeString = WARN_MESSAGE;
+      default:
+        badgeString = ERROR_MESSAGE;
+    }
+    return badgeString;
   }
 
 }

--- a/src/main/java/hudson/plugins/sonar/client/ProjectInformation.java
+++ b/src/main/java/hudson/plugins/sonar/client/ProjectInformation.java
@@ -36,6 +36,7 @@ public class ProjectInformation extends InvisibleAction {
   private final String ERROR_MESSAGE = "Failed";
   private final String OK_MESSAGE = "Passed";
   private final String WARN_MESSAGE = "Warning";
+  private final String UNKOWN_MESSAGE = "N/A";
 
   public ProjectInformation() {
     this.created = System.currentTimeMillis();
@@ -112,8 +113,10 @@ public class ProjectInformation extends InvisibleAction {
         badgeString = OK_MESSAGE;
       case "WARN": 
         badgeString = WARN_MESSAGE;
-      default:
+      case "ERROR":
         badgeString = ERROR_MESSAGE;
+      default:
+        badgeString = UNKOWN_MESSAGE;
     }
     return badgeString;
   }

--- a/src/main/resources/hudson/plugins/sonar/action/SonarProjectPageAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/sonar/action/SonarProjectPageAction/jobMain.jelly
@@ -10,7 +10,7 @@
 	    <table class="sonar-projects">
 	    
 	    <j:forEach var="project" items="${projects}">
-		  <j:set var="status" value="${project.getStatus()}" />  
+		  <j:set var="status" value="${project.getBadgeStatus()}" />  
 		  <j:set var="ceStatus" value="${project.getCeStatus()}" />
 		  
 		  <j:if test="${status != null}">
@@ -22,10 +22,10 @@
 		      <div class="sonar-qg-status">
 		        <a href="${project.getUrl()}"> 
 		          <j:choose>
-		            <j:when test="${status=='OK'}">
+		            <j:when test="${status=='Passed'}">
 		              <div class="badge badge-success"> ${status}</div>
 		            </j:when>
-		            <j:when test="${status=='WARN'}">
+		            <j:when test="${status=='Warning'}">
 		              <div class="badge badge-warning"> ${status}</div>
 		            </j:when>
 		            <j:otherwise>

--- a/src/main/resources/hudson/plugins/sonar/action/SonarProjectPageAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/sonar/action/SonarProjectPageAction/jobMain.jelly
@@ -28,8 +28,11 @@
 		            <j:when test="${status=='Warning'}">
 		              <div class="badge badge-warning"> ${status}</div>
 		            </j:when>
-		            <j:otherwise>
+		            <j:when test="${status=='Failed'}">
 		              <div class="badge badge-failing"> ${status}</div>
+		            </j:when>
+		            <j:otherwise>
+		              <div class="badge badge-warning"> ${status}</div>
 		            </j:otherwise>
 		          </j:choose>
 		        </a>


### PR DESCRIPTION
This merge simply renames the Quality Gate status as follows:

- `OK` to `Passed`
- `ERROR` to `Failed`
- `WARN` to `Warning`
-  All others or empty to `N/A`

Which will be the same as the SonarQube ones. Also, they are more readable for the end-users. 

**Example screenshot**:
![image](https://user-images.githubusercontent.com/7557299/86284841-44d97780-bbec-11ea-9585-84fe21b634c5.png)
