### PR TITLE
Adds CLI flag for using withSonarQubeEnv solely for credentials

### DIFF
--- a/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
@@ -71,8 +71,9 @@ import org.kohsuke.stapler.QueryParameter;
 import static org.apache.commons.lang3.StringEscapeUtils.escapeJson;
 
 public class SonarBuildWrapper extends SimpleBuildWrapper {
-  private String installationName = null;
+  private String installationName;
   private String credentialsId;
+  private boolean cli = true;
 
   @DataBoundConstructor
   public SonarBuildWrapper(@Nullable String installationName) {
@@ -89,6 +90,9 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
     this.credentialsId = Util.fixEmpty(credentialsId);
   }
 
+  @DataBoundSetter
+  public void setCli(boolean cli) { this.cli = cli; }
+
   @Override
   public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment)
     throws IOException, InterruptedException {
@@ -101,6 +105,10 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
     listener.getLogger().println(msg);
 
     context.getEnv().putAll(createVars(installation, getCredentialsId(), initialEnvironment, build));
+
+    if (!cli) {
+      return;
+    }
 
     context.setDisposer(new AddBuildInfo(installation, getCredentialsId()));
 

--- a/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
@@ -89,7 +89,7 @@ public final class SonarUtils {
       candidates = workspace.list("**/" + REPORT_TASK_FILE_NAME);
     }
     if (candidates == null || candidates.length == 0) {
-      listener.getLogger().println("WARN: Unable to locate '" + REPORT_TASK_FILE_NAME + "' in the workspace. Did the SonarScanner succeeded?");
+      listener.getLogger().println("WARN: Unable to locate '" + REPORT_TASK_FILE_NAME + "' in the workspace. Did the SonarScanner succeed?");
       return null;
     } else {
       if (candidates.length > 1) {


### PR DESCRIPTION
The intent here is to be able to write something like:

```groovy
withSonarQubeEnv('SonarQube', cli: false) {
  final url = "$env.SONAR_HOST_URL/api/issues/search?componentKeys=my-app&resolved=no&ps=100"
  readJSON(text: sh(returnStdout: true, script: "curl -ksS -u $env.SONAR_AUTH_TOKEN: '$url'")).issues
}
```

without receiving this menacing/misleading warning:

```
WARN: Unable to locate ‘report-task.txt’ in the workspace. Did the SonarScanner succedeed?
```

See discussion here:

https://community.sonarsource.com/t/sonarqube-scanner-for-jenkins-suppress-report-task-txt-warning/27410