### PR TITLE
Add a timeout option to the HttpClient to fix a bug

### DIFF
--- a/src/main/java/hudson/plugins/sonar/client/HttpClient.java
+++ b/src/main/java/hudson/plugins/sonar/client/HttpClient.java
@@ -26,10 +26,14 @@ import org.sonarqube.ws.client.HttpConnector;
 import org.sonarqube.ws.client.WsResponse;
 
 public class HttpClient {
-  public String getHttp(String url, @Nullable String token) {
+  public String getHttp(String url, @Nullable String token, @Nullable Float timeout_ms) {
     String baseUrl = StringUtils.substringBeforeLast(url, "/");
     String path = StringUtils.substringAfterLast(url, "/");
+    Float connect_timout = defaultIfBlank(timeout_ms, 5_000)
+    Float read_timout = defaultIfBlank(timeout_ms, 5_000)
     HttpConnector httpConnector = HttpConnector.newBuilder()
+      .readTimeoutMilliseconds(read_timout)
+      .connectTimeoutMilliseconds(connect_timout)
       .userAgent("Scanner for Jenkins")
       .url(baseUrl)
       .credentials(token, null)

--- a/src/main/java/hudson/plugins/sonar/client/HttpClient.java
+++ b/src/main/java/hudson/plugins/sonar/client/HttpClient.java
@@ -25,12 +25,15 @@ import org.sonarqube.ws.client.GetRequest;
 import org.sonarqube.ws.client.HttpConnector;
 import org.sonarqube.ws.client.WsResponse;
 
+import static org.apache.commons.lang.StringUtils.defaultIfBlank;
+import static java.lang.Integer.parseInt;
+
 public class HttpClient {
-  public String getHttp(String url, @Nullable String token, @Nullable Float timeout_ms) {
+  public String getHttp(String url, @Nullable String token) {
     String baseUrl = StringUtils.substringBeforeLast(url, "/");
     String path = StringUtils.substringAfterLast(url, "/");
-    Float connect_timout = defaultIfBlank(timeout_ms, 5_000)
-    Float read_timout = defaultIfBlank(timeout_ms, 5_000)
+    Integer connect_timout = 5_000;
+    Integer read_timout = 10_000;
     HttpConnector httpConnector = HttpConnector.newBuilder()
       .readTimeoutMilliseconds(read_timout)
       .connectTimeoutMilliseconds(connect_timout)

--- a/src/main/java/hudson/plugins/sonar/client/WsClient.java
+++ b/src/main/java/hudson/plugins/sonar/client/WsClient.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
-import org.apache.commons.lang.ObjectUtils;
 
 public class WsClient {
   private static final String STATUS_ATTR = "status";
@@ -49,8 +48,7 @@ public class WsClient {
 
   public CETask getCETask(String taskId) {
     String url = serverUrl + API_CE_TASK + taskId;
-    String http = client.getHttp(url, token);
-    String text = http;
+    String text = client.getHttp(url, token);
     try {
       JSONObject json = (JSONObject) JSONSerializer.toJSON(text);
       JSONObject task = json.getJSONObject("task");

--- a/src/main/java/hudson/plugins/sonar/client/WsClient.java
+++ b/src/main/java/hudson/plugins/sonar/client/WsClient.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
+import org.apache.commons.lang.ObjectUtils;
 
 public class WsClient {
   private static final String STATUS_ATTR = "status";
@@ -48,7 +49,8 @@ public class WsClient {
 
   public CETask getCETask(String taskId) {
     String url = serverUrl + API_CE_TASK + taskId;
-    String text = client.getHttp(url, token);
+    String http = client.getHttp(url, token);
+    String text = http;
     try {
       JSONObject json = (JSONObject) JSONSerializer.toJSON(text);
       JSONObject task = json.getJSONObject("task");


### PR DESCRIPTION
Naive first pass at introducing a default timeout
to HttpClient.java to fix a bug where the request will hang
on a non-response from a call to /api/server/version from
the Jenkins Master. The default timeout from HttpConnector is
a very long 30s to connect and 60s to read.

I couldn't figure out how to test this locally, but if introducing a change like this seems viable and there is a local development type doc I can reference I can clean it up a bit to fit that. I've never written Jenkins plugins, but we use this one and ran into an issue today with it when the master couldn't talk to /api/server/version. Not sure why it even needed to reach that, and when we used /etc/hosts to just route that request to a failed connection that solved our issue. I figure I should try to solve this problem for other people by making an upstream change.