### PR TITLE
SC-2555 Mark pipeline as unstable when running Java < 11

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,9 +75,9 @@ linux_qa_task:
     BROWSER: chrome
     matrix:
       - SQ_VERSION: LATEST_RELEASE[7.9]
-        JENKINS_VERSION: 2.176.4
+        JENKINS_VERSION: 2.265
       - SQ_VERSION: DEV
-        JENKINS_VERSION: 2.176.4
+        JENKINS_VERSION: 2.265
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   qa_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,9 +75,9 @@ linux_qa_task:
     BROWSER: chrome
     matrix:
       - SQ_VERSION: LATEST_RELEASE[7.9]
-        JENKINS_VERSION: 2.265
+        JENKINS_VERSION: 2.190.1
       - SQ_VERSION: DEV
-        JENKINS_VERSION: 2.265
+        JENKINS_VERSION: 2.190.1
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   qa_script:


### PR DESCRIPTION
The SonarCloud scanner logs a warning message when the scanner is executed with a Java version under 11. This change will mark the pipeline as unstable if it can find that log message. 

We saw from data that mainly Jenkins users are not making the switch to Java 11 so that's why we decided to focus on Jenkins specifically.