### PR TITLE
update(links): change html <a> elements to open in new tabs

### DIFF
--- a/src/main/resources/hudson/plugins/sonar/action/SonarBuildBadgeAction/badge.jelly
+++ b/src/main/resources/hudson/plugins/sonar/action/SonarBuildBadgeAction/badge.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<a href="${it.urlName}">
+<a href="${it.urlName}" target="_blank" rel="noopener noreferrer" >
 <img width="16" height="16"
      title="${it.tooltip}" alt="[sonarqube]"
      src="${rootURL}${it.icon}"/>

--- a/src/main/resources/hudson/plugins/sonar/action/SonarProjectPageAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/sonar/action/SonarProjectPageAction/jobMain.jelly
@@ -20,7 +20,7 @@
 		      <div class="sonar-qg-label">${project.getProjectName()}</div>
 		  
 		      <div class="sonar-qg-status">
-		        <a href="${project.getUrl()}"> 
+		        <a href="${project.getUrl()}" target="_blank" rel="noopener noreferrer" >
 		          <j:choose>
 		            <j:when test="${status=='Passed'}">
 		              <div class="badge badge-success"> ${status}</div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -3,6 +3,6 @@
 This view is used to render the installed plugins page.
 -->
 <div>
-  This plugin allows an easy integration of <a href="http://www.sonarqube.org/">SonarQube</a>,
+  This plugin allows an easy integration of <a href="http://www.sonarqube.org/" target="_blank" rel="noopener noreferrer" >SonarQube</a>,
   the open source platform for Continuous Inspection of code quality.
 </div>


### PR DESCRIPTION
**Description**

Recently we started using SonarQube more and more in our Jenkins pipelines and I got kind of triggered by the links on the job page opening within the same window instead of new tabs.
To remedy this (assuming I am not alone with this "issue") I now open this PR that does nothing besides adding `target="_blank" rel="noopener noreferrer"` to all the HTML <a> elements I could find and where it made sense to add it.

I hope this PR is acceptable since I could not locate any contributions guideline. Regardless thank you for this plugin :+1: 

**Changes**

* set HTML <a> elements to open links in new tab per default

**Issues**

* N/A