### PR TITLE
update(ci): add dependabot config for dependency patching

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,13 @@
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  # Fetch and update latest `maven` packages
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope


### PR DESCRIPTION
**Description**

Based on my other PR I noticed that this repo has no [Dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates#enabling-dependabot-version-updates) config.
In case you want to use it I open this PR to add such a config to scan weekly for dependency updates and open at most 10 PRs at the same time.

Up to you if you find this useful :wink: 

**Changes**

* add dependabot v2 config

**Issues**

* N/A