### PR TITLE
Remove tabular markup from forms

### DIFF
--- a/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:s="/lib/sonar">
          
   <f:section title="${%Title}">
     <f:entry title="${%InjectVarsTitle}" description="${%InjectVarsDesc}">
@@ -10,7 +10,7 @@
     <f:entry title="${%SonarInstallations}" description="${%SonarInstallationsDescr}">
       <div class="sonar-section">
       <f:repeatable var="inst" items="${instance.installations}" add="${%AddSonar}">
-        <table width="100%" class="sonar-installation">
+        <s:blockWrapper class="sonar-installation">
           <f:entry title="${%Name}">
             <f:textbox name="sonar.name" value="${inst.getName()}" checkUrl="'${rootURL}/descriptor/SonarGlobalConfiguration/checkMandatory?value='+escape(this.value)"/>
           </f:entry>
@@ -50,7 +50,7 @@
               <f:repeatableDeleteButton value="${%DeleteSonar}"/>
             </div>
           </f:entry>
-        </table>
+        </s:blockWrapper>
       </f:repeatable>
       </div>
     </f:entry>

--- a/src/main/resources/hudson/plugins/sonar/SonarPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarPublisher/config.jelly
@@ -1,6 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:s="/lib/sonar">
 
   <f:block>
     <p style="color:red">
@@ -85,13 +84,13 @@
     </f:entry>
     <!-- Build Triggers -->
     <f:nested>
-      <table width="100%">
+      <s:blockWrapper>
         <f:optionalBlock name="sonar.triggers" title="${%DontUseGlobalTriggers}"
                          checked="${instance.isUseLocalTriggers()}"
                          help="/plugin/sonar/help-trigger-global.html">
           <st:include class="${descriptor.clazz}" page="triggers.jelly" it="${instance.getTriggers()}"/>
         </f:optionalBlock>
-      </table>
+      </s:blockWrapper>
     </f:nested>
   </f:advanced>
 

--- a/src/main/resources/lib/sonar/blockWrapper.jelly
+++ b/src/main/resources/lib/sonar/blockWrapper.jelly
@@ -1,0 +1,19 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler">
+    <!-- TODO remove and switch to div after baseline is 2.264 or newer -->
+    <st:documentation>
+        <st:attribute name="class"/>
+    </st:documentation>
+    <j:choose>
+        <j:when test="${divBasedFormLayout}">
+            <div class="${attrs.class}">
+                <d:invokeBody/>
+            </div>
+        </j:when>
+        <j:otherwise>
+            <table style="width:100%" class="${attrs.class}">
+                <d:invokeBody/>
+            </table>
+        </j:otherwise>
+    </j:choose>
+</j:jelly>

--- a/src/test/java/hudson/plugins/sonar/SonarTestCase.java
+++ b/src/test/java/hudson/plugins/sonar/SonarTestCase.java
@@ -76,8 +76,12 @@ public abstract class SonarTestCase {
   protected Maven.MavenInstallation configureDefaultMaven() throws Exception {
     File mvn = new File(getClass().getResource("SonarTestCase/maven/bin/mvn").toURI().getPath());
     if (!Functions.isWindows()) {
-      // noinspection OctalInteger
-      GNUCLibrary.LIBC.chmod(mvn.getPath(), 0755);
+      try {
+        // noinspection OctalInteger
+        GNUCLibrary.LIBC.chmod(mvn.getPath(), 0755);
+      } catch (Error e) {
+        e.printStackTrace();
+      }
     }
     String home = mvn.getParentFile().getParentFile().getAbsolutePath();
     Maven.MavenInstallation mavenInstallation = new Maven.MavenInstallation("default", home, JenkinsRule.NO_PROPERTIES);


### PR DESCRIPTION
Following https://www.jenkins.io/doc/developer/views/table-to-div-migration/

See https://www.jenkins.io/blog/2020/11/10/major-changes-in-weekly-releases/

I'm not sure if this is causing an issue but I'm working through all the plugins that appear with tabular markup in https://issues.jenkins.io/browse/JENKINS-64341