### PR TITLE
Use GitHub as the source of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ SonarQube Scanner for Jenkins
 
 [![Build Status](https://travis-ci.org/SonarSource/sonar-scanner-jenkins.svg?branch=master)](https://travis-ci.org/SonarSource/sonar-scanner-jenkins) [![Quality Gate](https://next.sonarqube.com/sonarqube/api/project_badges/measure?project=org.jenkins-ci.plugins%3Asonar&metric=alert_status)](https://next.sonarqube.com/sonarqube/dashboard?id=org.jenkins-ci.plugins%3Asonar)
 
+This plugin allow easy integration of [SonarQube™](https://www.sonarqube.org/), the open source platform for Continuous Inspection of code quality.
+
 Documentation: http://redirect.sonarsource.com/plugins/jenkins.html
 
 Issue tracking: https://jira.sonarsource.com/browse/SONARJNKNS

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <packaging>hpi</packaging>
 
   <name>SonarQube Scanner for Jenkins</name>
-  <url>http://redirect.sonarsource.com/plugins/jenkins.html</url>
+  <url>https://github.com/jenkinsci/sonarqube-plugin</url>
   <inceptionYear>2007</inceptionYear>
   <organization>
     <name>SonarSource</name>
@@ -24,7 +24,7 @@
   <licenses>
     <license>
       <name>GNU Lesser General Public License (LGPL), v.3</name>
-      <url>http://www.gnu.org/licenses/lgpl.txt</url>
+      <url>https://www.gnu.org/licenses/lgpl.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -37,7 +37,7 @@
   </scm>
   <issueManagement>
     <system>JIRA</system>
-    <url>http://jira.sonarsource.com/browse/SONARJNKNS</url>
+    <url>https://jira.sonarsource.com/browse/SONARJNKNS</url>
   </issueManagement>
   <ciManagement>
     <system>Travis</system>


### PR DESCRIPTION
Replaces https://github.com/jenkinsci/sonarqube-plugin/pull/9

The reason to use GitHub URL is that  https://plugins.jenkins.io/sonar/ can only pull information from the Wiki (which is in read only mode and will be turned off eventually) or GitHub (the preferred way).