### PR TITLE
NO-JIRA bumping jenkins version that we use for ITs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,9 +75,9 @@ linux_qa_task:
     BROWSER: chrome
     matrix:
       - SQ_VERSION: LATEST_RELEASE[8.9]
-        JENKINS_VERSION: 2.204.6
+        JENKINS_VERSION: 2.222.4
       - SQ_VERSION: DEV
-        JENKINS_VERSION: 2.204.6
+        JENKINS_VERSION: 2.222.4 ### https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   qa_script:


### PR DESCRIPTION
This is the version that Jenkins recommends 

> Do not use versions no longer supported by the update center, which is currently anything older than 2.238 for weekly releases, and 2.222.4 for LTS releases.