### PR TITLE
[JENKINS-66308] Prepare SonarQube Scanner for core Guava upgrade

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <!-- See https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md -->
-    <version>3.54</version>
+    <version>4.24</version>
     <relativePath />
   </parent>
 
   <artifactId>sonar</artifactId>
-  <version>2.14-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>SonarQube Scanner for Jenkins</name>
@@ -30,10 +30,10 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/sonarqube-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/sonarqube-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/sonarqube-plugin</url>
-    <tag>HEAD</tag>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <tag>${scmTag}</tag>
   </scm>
   <issueManagement>
     <system>JIRA</system>
@@ -45,12 +45,15 @@
   </ciManagement>
 
   <properties>
+    <revision>2.14</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>SonarSource/sonar-scanner-jenkins</gitHubRepo>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <hudson.version>${project.parent.version}</hudson.version>
     <sonar.exclusions>target/generated-sources/**/*</sonar.exclusions>
     <gitRepositoryName>sonar-scanner-jenkins</gitRepositoryName>
     <version.artifactory.plugin>2.6.1</version.artifactory.plugin>
-    <jenkins.version>2.150.3</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
     <findbugs.failOnError>false</findbugs.failOnError>
     <!-- Disable parallel tests on Travis -->
@@ -74,19 +77,26 @@
     <dependencies>
       <!-- Resolve dependency conflicts of plugins used during tests (workflow) -->
       <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.6</version>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>3.11.1</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.ant</groupId>
-        <artifactId>ant</artifactId>
-        <version>1.10.11</version>
+        <groupId>com.jcraft</groupId>
+        <artifactId>jsch</artifactId>
+        <version>0.1.55</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-embedder</artifactId>
-        <version>3.5.0</version>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>887.vae9c8ac09ff7</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>2.10.2</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
@@ -109,6 +119,11 @@
         <version>3.5.0</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-embedder</artifactId>
+        <version>3.5.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.5.13</version>
@@ -116,22 +131,17 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.4.13</version>
+        <version>4.4.14</version>
       </dependency>
       <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-step-api</artifactId>
-        <version>2.14</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>ssh-credentials</artifactId>
-        <version>1.13</version>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.11.3</version>
       </dependency>
       <dependency>
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
-        <version>3.6</version>
+        <version>3.8.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -139,7 +149,11 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
+      <version>3.11</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>caffeine-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
@@ -162,18 +176,15 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
-      <version>3.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.13</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
-      <version>1.4</version>
     </dependency>
     <!-- Webhook secret validation -->
     <dependency>
@@ -209,56 +220,46 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.45</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.14</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
-      <version>1.2.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>1.32</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
-      <version>1.32</version>
-      <classifier>tests</classifier>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
+++ b/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
@@ -20,8 +20,8 @@
 package hudson.plugins.sonar.client;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import hudson.model.Run;
 import hudson.plugins.sonar.SonarInstallation;
 import hudson.plugins.sonar.client.WsClient.CETask;
@@ -35,7 +35,7 @@ import org.sonarqube.ws.client.HttpException;
 
 public class SQProjectResolver {
   @VisibleForTesting
-  static final Cache<String, Version> INSTANCE_VERSION_CACHE = CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();
+  static final Cache<String, Version> INSTANCE_VERSION_CACHE = Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();
   private final HttpClient client;
 
   public SQProjectResolver(HttpClient client) {
@@ -63,7 +63,7 @@ public class SQProjectResolver {
       String serverAuthenticationToken = inst.getServerAuthenticationToken(build);
       WsClient wsClient = new WsClient(client, serverUrl, serverAuthenticationToken);
 
-      Version version = INSTANCE_VERSION_CACHE.get(installationName, () -> new Version(wsClient.getServerVersion()));
+      Version version = INSTANCE_VERSION_CACHE.get(installationName, value -> new Version(wsClient.getServerVersion()));
 
       if (version.compareTo(new Version("5.6")) < 0) {
         Logger.LOG.info(() -> "SQ < 5.6 is not supported");

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHook.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHook.java
@@ -20,8 +20,8 @@
 package org.sonarsource.scanner.jenkins.pipeline;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import hudson.Extension;
 import hudson.model.RootAction;
 import hudson.model.UnprotectedRootAction;
@@ -46,7 +46,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 @Extension
 public class SonarQubeWebHook implements UnprotectedRootAction {
   private static final Logger LOGGER = Logger.getLogger(SonarQubeWebHook.class.getName());
-  private final Cache<String, WebhookEvent> eventCache = CacheBuilder.newBuilder().expireAfterWrite(2, TimeUnit.HOURS).build();
+  private final Cache<String, WebhookEvent> eventCache = Caffeine.newBuilder().expireAfterWrite(2, TimeUnit.HOURS).build();
   public static final String URLNAME = "sonarqube-webhook";
 
   @VisibleForTesting


### PR DESCRIPTION
See [JENKINS-66308](https://issues.jenkins.io/browse/JENKINS-66308) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.cache.Cache#get(K key)` API, which has been removed between Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/cache/Cache.html) and [latest](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/cache/Cache.html). The removal took place in Guava 12.0.

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. The recommendation is for plugins to migrate from Guava's cache to [Caffeine](https://github.com/ben-manes/caffeine) via the Jenkins [Caffeine API](https://plugins.jenkins.io/caffeine-api/) plugin.

For the most part, the migration is a trivial matter of replacing imports of `com.google.common.cache.Cache` with imports of `com.github.benmanes.caffeine.cache.Cache` and imports of `com.google.common.cache.CacheBuilder` with imports of `com.github.benmanes.caffeine.cache.Caffeine`. This has already been done in other plugins in the following PRs:

- jenkinsci/active-directory-plugin#109
- jenkinsci/azure-ad-plugin#125
- jenkinsci/configuration-as-code-plugin#1596
- jenkinsci/kubernetes-plugin#991
- jenkinsci/lockable-resources-plugin#242
- jenkinsci/role-strategy-plugin#150