### PR TITLE
[JENKINS-66353] No public field webhookSecretId

### DIFF
--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
@@ -141,6 +141,10 @@ public class WaitForQualityGateStep extends Step implements Serializable {
     return credentialsId;
   }
 
+  public String getWebhookSecretId() {
+    return webhookSecretId;
+  }
+
   @DataBoundSetter
   public void setCredentialsId(@Nullable String credentialsId) {
     this.credentialsId = Util.fixEmpty(credentialsId);

--- a/src/test/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStepTest.java
+++ b/src/test/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStepTest.java
@@ -110,6 +110,13 @@ public class WaitForQualityGateStepTest {
   }
 
   @Test
+  public void getWebhookSecretId() {
+    WaitForQualityGateStep waitForQualityGateStep = new WaitForQualityGateStep(true);
+    waitForQualityGateStep.setWebhookSecretId("AV4p2424BJY0hh5C8Sya1ZS234234");
+    assertThat(waitForQualityGateStep.getWebhookSecretId()).isEqualTo("AV4p2424BJY0hh5C8Sya1ZS234234");
+  }
+
+  @Test
   public void failIfNoTaskIdInContext() {
     story.addStep(new Statement() {
       @Override


### PR DESCRIPTION
When trying to generate the code snippet for quality gate step `WaitForQualityGateStep`, we are experiencing the error:

`no public field 'webhookSecretId' (or getter method) found in class org.sonarsource.scanner.jenkins.pipeline.WaitForQualityGateStep`

The created PR only add a getter method for the field webhookSecretId. 

Jira issue: https://issues.jenkins.io/browse/JENKINS-66353
