### PR TITLE
SONARJNKNS-331 IT failing on setting up Scanner for MSBuild

### DIFF
--- a/its/src/test/java/com/sonar/it/jenkins/ScannerSupportedVersionProvider.java
+++ b/its/src/test/java/com/sonar/it/jenkins/ScannerSupportedVersionProvider.java
@@ -40,14 +40,27 @@ public class ScannerSupportedVersionProvider {
    */
   public String getEarliestSupportedVersion(String scannerNameRepo) {
     try {
-      HttpUrl.Builder httpBuilder = HttpUrl
-          .parse(String.format("https://api.github.com/repos/SonarSource/%s/releases", scannerNameRepo)).newBuilder();
-      Request request = new Request.Builder().url(httpBuilder.build()).build();
-      Response response = client.newCall(request).execute();
-      JSONArray array = new JSONArray(response.body().string());
-      return ((JSONObject) array.get(array.length() - 1)).getString("tag_name");
+      JSONArray array = getSupportVersions(scannerNameRepo);
+      return ((JSONObject) array.get(1)).getString("tag_name");
     } catch (IOException | JSONException e) {
       throw new IllegalStateException(String.format("Could not fetch earliest supported version of %s", scannerNameRepo), e);
     }
+  }
+
+  public String getLatestSupportedVersion(String scannerNameRepo) {
+    try {
+      JSONArray array = getSupportVersions(scannerNameRepo);
+      return ((JSONObject) array.get(0)).getString("tag_name");
+    } catch (IOException | JSONException e) {
+      throw new IllegalStateException(String.format("Could not fetch latest supported version of %s", scannerNameRepo), e);
+    }
+  }
+
+  private JSONArray getSupportVersions(String scannerNameRepo) throws IOException, JSONException {
+    HttpUrl.Builder httpBuilder = HttpUrl
+      .parse(String.format("https://api.github.com/repos/SonarSource/%s/releases", scannerNameRepo)).newBuilder();
+    Request request = new Request.Builder().url(httpBuilder.build()).build();
+    Response response = client.newCall(request).execute();
+    return new JSONArray(response.body().string());
   }
 }

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
@@ -75,11 +75,11 @@ public class SonarPluginTest extends AbstractJUnitTest {
   private static final String DUMP_ENV_VARS_PIPELINE_CMD = SystemUtils.IS_OS_WINDOWS ? "bat 'set'" : "sh 'env | sort'";
   private static final String SECRET = "very_secret_secret";
   private static final String JENKINS_VERSION = "3.3.0.1492";
-  private static final String MS_BUILD_RECENT_VERSION = "4.7.1.2311";
   private static final String MVN_PROJECT_KEY = "org.codehaus.sonar-plugins:sonar-abacus-plugin";
   private static String DEFAULT_QUALITY_GATE_NAME;
 
   private static String EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION;
+  private static String MS_BUILD_RECENT_VERSION;
 
   @ClassRule
   public static final Orchestrator ORCHESTRATOR = Orchestrator.builderEnv()
@@ -109,6 +109,9 @@ public class SonarPluginTest extends AbstractJUnitTest {
 
     EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION = SCANNER_VERSION_PROVIDER
         .getEarliestSupportedVersion("sonar-scanner-msbuild");
+
+    MS_BUILD_RECENT_VERSION = SCANNER_VERSION_PROVIDER
+      .getLatestSupportedVersion("sonar-scanner-msbuild");
   }
 
   @Before


### PR DESCRIPTION
The IT tries to setup the oldest released version of the Scanner for MSBuild. It does this by using a select list in the administration section. However, this list is only showing 2 versions, and the oldest released version is not part of it:

<img width="685" alt="Screenshot 2021-08-30 at 15 49 08" src="https://user-images.githubusercontent.com/45544358/131483616-fae2258d-32e3-442f-8e6d-a3ef13f682c7.png">

Hence, the IT fails, not finding the option in the list.

I don't understand where this comes from, but in order to stabilize the QA, I've made the ITs select only the 1st two options, which corresponds to the current behavior of our plugin (which might be a regression, BTW, but I couldn't pin-point the commit that introduced this change).