### PR TITLE
Revert "SONARJNKNS-331 IT failing on setting up Scanner for MSBuild"

### DIFF
--- a/its/src/test/java/com/sonar/it/jenkins/ScannerSupportedVersionProvider.java
+++ b/its/src/test/java/com/sonar/it/jenkins/ScannerSupportedVersionProvider.java
@@ -40,27 +40,14 @@ public class ScannerSupportedVersionProvider {
    */
   public String getEarliestSupportedVersion(String scannerNameRepo) {
     try {
-      JSONArray array = getSupportVersions(scannerNameRepo);
-      return ((JSONObject) array.get(1)).getString("tag_name");
+      HttpUrl.Builder httpBuilder = HttpUrl
+          .parse(String.format("https://api.github.com/repos/SonarSource/%s/releases", scannerNameRepo)).newBuilder();
+      Request request = new Request.Builder().url(httpBuilder.build()).build();
+      Response response = client.newCall(request).execute();
+      JSONArray array = new JSONArray(response.body().string());
+      return ((JSONObject) array.get(array.length() - 1)).getString("tag_name");
     } catch (IOException | JSONException e) {
       throw new IllegalStateException(String.format("Could not fetch earliest supported version of %s", scannerNameRepo), e);
     }
-  }
-
-  public String getLatestSupportedVersion(String scannerNameRepo) {
-    try {
-      JSONArray array = getSupportVersions(scannerNameRepo);
-      return ((JSONObject) array.get(0)).getString("tag_name");
-    } catch (IOException | JSONException e) {
-      throw new IllegalStateException(String.format("Could not fetch latest supported version of %s", scannerNameRepo), e);
-    }
-  }
-
-  private JSONArray getSupportVersions(String scannerNameRepo) throws IOException, JSONException {
-    HttpUrl.Builder httpBuilder = HttpUrl
-      .parse(String.format("https://api.github.com/repos/SonarSource/%s/releases", scannerNameRepo)).newBuilder();
-    Request request = new Request.Builder().url(httpBuilder.build()).build();
-    Response response = client.newCall(request).execute();
-    return new JSONArray(response.body().string());
   }
 }

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
@@ -75,11 +75,11 @@ public class SonarPluginTest extends AbstractJUnitTest {
   private static final String DUMP_ENV_VARS_PIPELINE_CMD = SystemUtils.IS_OS_WINDOWS ? "bat 'set'" : "sh 'env | sort'";
   private static final String SECRET = "very_secret_secret";
   private static final String JENKINS_VERSION = "3.3.0.1492";
+  private static final String MS_BUILD_RECENT_VERSION = "4.7.1.2311";
   private static final String MVN_PROJECT_KEY = "org.codehaus.sonar-plugins:sonar-abacus-plugin";
   private static String DEFAULT_QUALITY_GATE_NAME;
 
   private static String EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION;
-  private static String MS_BUILD_RECENT_VERSION;
 
   @ClassRule
   public static final Orchestrator ORCHESTRATOR = Orchestrator.builderEnv()
@@ -109,9 +109,6 @@ public class SonarPluginTest extends AbstractJUnitTest {
 
     EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION = SCANNER_VERSION_PROVIDER
         .getEarliestSupportedVersion("sonar-scanner-msbuild");
-
-    MS_BUILD_RECENT_VERSION = SCANNER_VERSION_PROVIDER
-      .getLatestSupportedVersion("sonar-scanner-msbuild");
   }
 
   @Before


### PR DESCRIPTION
This reverts commit c4711338d2d80d43122a106de7c567095faa39e1, introduced by https://github.com/SonarSource/sonar-scanner-jenkins/pull/206.

The root cause, which caused the QA to fail, will be reverted once [this PR](https://github.com/jenkins-infra/crawler/pull/109) is approved. Once that is merged, we should revert the update to our ITs.
