### PR TITLE
Fix nightly QA

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,10 +74,12 @@ linux_qa_task:
   env:
     BROWSER: chrome
     matrix:
+      # If updating the JENKINS_VERSION, make sure that all installed plugins are compatible. See com.sonar.it.jenkins.SonarPluginTest
+      # https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/
       - SQ_VERSION: LATEST_RELEASE[8.9]
         JENKINS_VERSION: 2.277.1
       - SQ_VERSION: DEV
-        JENKINS_VERSION: 2.277.1 ### https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/
+        JENKINS_VERSION: 2.277.1
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   qa_script:

--- a/its/src/test/java/com/sonar/it/jenkins/JenkinsUtils.java
+++ b/its/src/test/java/com/sonar/it/jenkins/JenkinsUtils.java
@@ -441,17 +441,6 @@ public class JenkinsUtils {
     });
   }
 
-  public void assertNoSonarPublisher(String jobName, File projectPath) {
-    try {
-      newFreestyleJobConfig(jobName, projectPath);
-      findElement(buttonByText("Add post-build action")).click();
-      assertNoElement(MAVEN_POST_BUILD_LABEL);
-      // Save to avoid alert asking if we want to leave
-    } finally {
-      findElement(buttonByText("Save")).click();
-    }
-  }
-
   public void select(WebElement element, String optionValue) {
     Select select = new Select(element);
     select.selectByValue(optionValue);

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
@@ -74,7 +74,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
 
   private static final String DUMP_ENV_VARS_PIPELINE_CMD = SystemUtils.IS_OS_WINDOWS ? "bat 'set'" : "sh 'env | sort'";
   private static final String SECRET = "very_secret_secret";
-  private static final String JENKINS_VERSION = "3.3.0.1492";
+  private static final String SONARQUBE_SCANNER_VERSION = "3.3.0.1492";
   private static final String MS_BUILD_RECENT_VERSION = "4.7.1.2311";
   private static final String MVN_PROJECT_KEY = "org.codehaus.sonar-plugins:sonar-abacus-plugin";
   private static String DEFAULT_QUALITY_GATE_NAME;
@@ -128,7 +128,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
 
   @Test
   public void testFreestyleJobWithSonarQubeScanner_use_sq_scanner_3_3() {
-    SonarScannerInstallation.install(jenkins, JENKINS_VERSION);
+    SonarScannerInstallation.install(jenkins, SONARQUBE_SCANNER_VERSION);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR);
 
     String jobName = "js-runner-sq-3.3";
@@ -147,7 +147,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
     } else {
       assertThat(result.getConsole()).contains("sonar-scanner -Duseless=Y");
     }
-    assertThat(result.getConsole()).contains("SonarQube Scanner 3.3.0.1492");
+    assertThat(result.getConsole()).contains("SonarQube Scanner " + SONARQUBE_SCANNER_VERSION);
 
     waitForComputationOnSQServer();
     assertThat(getProject(projectKey)).isNotNull();
@@ -358,7 +358,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   @Test
   @WithPlugins("workflow-aggregator")
   public void qualitygate_pipeline_ok() {
-    SonarScannerInstallation.install(jenkins, JENKINS_VERSION);
+    SonarScannerInstallation.install(jenkins, SONARQUBE_SCANNER_VERSION);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR);
 
     StringBuilder script = new StringBuilder();
@@ -385,7 +385,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   @Test
   @WithPlugins("workflow-aggregator")
   public void qualitygate_pipeline_ko() {
-    SonarScannerInstallation.install(jenkins, JENKINS_VERSION);
+    SonarScannerInstallation.install(jenkins, SONARQUBE_SCANNER_VERSION);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR);
 
     String previousDefault = getDefaultQualityGateName();

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
@@ -67,7 +67,7 @@ import org.sonarqube.ws.client.webhooks.CreateRequest;
 import org.sonarqube.ws.client.webhooks.DeleteRequest;
 import org.sonarqube.ws.client.webhooks.ListRequest;
 
-@WithPlugins({"sonar", "filesystem_scm", "plain-credentials"})
+@WithPlugins({"sonar", "git-server@1.10", "filesystem_scm@2.1", "plain-credentials@1.8"})
 public class SonarPluginTest extends AbstractJUnitTest {
 
   private static final ScannerSupportedVersionProvider SCANNER_VERSION_PROVIDER = new ScannerSupportedVersionProvider();
@@ -157,7 +157,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
 
   @Test
   @WithOS(os = WithOS.OS.WINDOWS)
-  @WithPlugins({"msbuild"})
+  @WithPlugins({"msbuild@1.30"})
   public void testFreestyleJobWithScannerForMsBuild() throws FailedExecutionException {
     MSBuildScannerInstallation.install(jenkins, MS_BUILD_RECENT_VERSION, false);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR)
@@ -195,7 +195,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
 
   @Test
   @WithOS(os = WithOS.OS.WINDOWS)
-  @WithPlugins({"msbuild"})
+  @WithPlugins({"msbuild@1.30"})
   public void testFreestyleJobWithScannerForMsBuild_3_0() {
     MSBuildScannerInstallation.install(jenkins, "2.3.2.573", false);
     MSBuildScannerInstallation.install(jenkins, EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION, false);
@@ -219,7 +219,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
 
   @Test
   @WithOS(os = WithOS.OS.WINDOWS)
-  @WithPlugins({"msbuild"})
+  @WithPlugins({"msbuild@1.30"})
   public void testFreestyleJobWithScannerForMsBuild_2_3_2() {
     MSBuildScannerInstallation.install(jenkins, "2.3.2.573", false);
     MSBuildScannerInstallation.install(jenkins, EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION, false);
@@ -241,7 +241,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test
-  @WithPlugins({"maven-plugin"})
+  @WithPlugins({"maven-plugin@3.18"})
   public void testMavenJob() {
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR)
       .configureMaven(ORCHESTRATOR);
@@ -257,7 +257,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test
-  @WithPlugins({"maven-plugin"})
+  @WithPlugins({"maven-plugin@3.18"})
   public void testVariableInjection() throws JenkinsUtils.FailedExecutionException {
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR)
       .configureMaven(ORCHESTRATOR);
@@ -275,7 +275,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test
-  @WithPlugins({"maven-plugin"})
+  @WithPlugins({"maven-plugin@3.18"})
   public void testFreestyleJobWithSonarMaven() {
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR)
       .configureMaven(ORCHESTRATOR);
@@ -292,7 +292,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test
-  @WithPlugins("workflow-aggregator")
+  @WithPlugins("workflow-aggregator@2.7")
   public void no_sq_vars_without_env_wrapper() throws JenkinsUtils.FailedExecutionException {
     String logs = runAndGetLogs("no-withSonarQubeEnv", DUMP_ENV_VARS_PIPELINE_CMD);
     try {
@@ -304,7 +304,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test
-  @WithPlugins("workflow-aggregator")
+  @WithPlugins("workflow-aggregator@2.7")
   public void env_wrapper_without_params_should_inject_sq_vars() {
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR);
 
@@ -313,7 +313,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test
-  @WithPlugins("workflow-aggregator")
+  @WithPlugins("workflow-aggregator@2.7")
   public void env_wrapper_with_specific_sq_should_inject_sq_vars() {
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR);
 
@@ -322,7 +322,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test(expected = JenkinsUtils.FailedExecutionException.class)
-  @WithPlugins("workflow-aggregator")
+  @WithPlugins("workflow-aggregator@2.7")
   public void env_wrapper_with_nonexistent_sq_should_fail() {
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR);
 
@@ -331,7 +331,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test
-  @WithPlugins({"workflow-aggregator", "msbuild"})
+  @WithPlugins({"workflow-aggregator@2.7", "msbuild@1.30"})
   @WithOS(os = WithOS.OS.WINDOWS)
   public void msbuild_pipeline() {
     MSBuildScannerInstallation.install(jenkins, EARLIEST_JENKINS_SUPPORTED_MS_BUILD_VERSION, false);
@@ -348,7 +348,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test
-  @WithPlugins("workflow-aggregator")
+  @WithPlugins("workflow-aggregator@2.7")
   public void qualitygate_pipeline_ok() {
     SonarScannerInstallation.install(jenkins, SONARQUBE_SCANNER_VERSION);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR);
@@ -375,7 +375,7 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test
-  @WithPlugins("workflow-aggregator")
+  @WithPlugins("workflow-aggregator@2.7")
   public void qualitygate_pipeline_ko() {
     SonarScannerInstallation.install(jenkins, SONARQUBE_SCANNER_VERSION);
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR);

--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
@@ -241,14 +241,6 @@ public class SonarPluginTest extends AbstractJUnitTest {
   }
 
   @Test
-  // Maven plugin no more installed by default in version 2
-  @Since("2.0")
-  public void testNoSonarPublisher() {
-    String jobName = "noSonarPublisher";
-    jenkinsOrch.assertNoSonarPublisher(jobName, new File("projects", "noPublisher"));
-  }
-
-  @Test
   @WithPlugins({"maven-plugin"})
   public void testMavenJob() {
     jenkinsOrch.configureSonarInstallation(ORCHESTRATOR)


### PR DESCRIPTION
The problem comes from incompatible plugin dependencies. This is likely one of the major reasons for all the instabilities we've had with our QA over the past months.

**Problem**
We install a fixed version of Jenkins (usually the LTS), but we always fetch the latest version of any plugin. This can cause issues, because:

- Some latest versions of plugins are not compatible with the running version of Jenkins, especially as a new LTS is published every 3 months.
- Some plugins have a shared dependency, but they might not require the same minimum version of that shared dependency. Jenkins will simply install the minimum version required by the first plugin that defines this dependency, which can fail the installation of another plugin that may require a higher version.

The problem is compounded by the fact this will fail "silently" (info only in the Jenkins logs), and the IT will continue its work, assuming the plugins were successfully installed. This is why they fail at stages like the plugin configuration screen, where expected options don't show up.

**Solution**
Pin the versions of all required plugins to something specific. If a dependency can cause a conflict due to different plugins requiring different versions, pin the version of this dependency to the most commonly compatible version and install it directly, don't treat it as a dependency. Pin everything, including Jenkins, to something that was working a few weeks ago, and keep it there for now.

This will hopefully stabilize our QA.