### PR TITLE
Bump up version of jenkins and jenkins-ci test harness (selenium)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,10 +77,10 @@ linux_qa_task:
       # If updating the JENKINS_VERSION, make sure that all installed plugins are compatible. See com.sonar.it.jenkins.SonarPluginTest
       # https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/
       - SQ_VERSION: LATEST_RELEASE[8.9]
-        JENKINS_VERSION: 2.289.1
+        JENKINS_VERSION: 2.332.4
         VERSION_OVERRIDES: git-server=1.9,sshd=3.0.3
       - SQ_VERSION: DEV
-        JENKINS_VERSION: 2.289.1
+        JENKINS_VERSION: 2.332.4
         VERSION_OVERRIDES: git-server=1.9,sshd=3.0.3
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>acceptance-test-harness</artifactId>
-      <version>1.96</version>
+      <version>1.110</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The integration tests are failing on the CI because some plugins can't be installed anymore.