### PR TITLE
SONARJNKNS-346 bump the Chrome and .NET versions used during ITs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,7 +65,7 @@ linux_qa_task:
   gke_container:
     dockerfile: its/docker/Dockerfile
     builder_image_project: sonarqube-team
-    builder_image_name: docker-builder-v20200915
+    builder_image_name: family/docker-builder
     cluster_name: cirrus-ci-cluster
     zone: us-central1-a
     namespace: default

--- a/cirrus/cirrus-qa.sh
+++ b/cirrus/cirrus-qa.sh
@@ -14,6 +14,7 @@ cd its
 # "ERROR: Multiple CI environments are detected: [CirrusCI, Jenkins]. Please check environment variables or set property sonar.ci.autoconfig.disabled to true."
 # We then need to explicly set the variable to false. Another solution would to do this in the IT itself, but couldn't find a way to do it yet.
 CIRRUS_CI=false
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 mvn -B -e -Dsonar.runtimeVersion="$SQ_VERSION" clean verify
 
 

--- a/its/docker/Dockerfile
+++ b/its/docker/Dockerfile
@@ -51,6 +51,8 @@ RUN INSTALLED_CHROME_VERSION=$(apt-cache policy google-chrome-stable | grep Inst
   && chmod 755 /usr/bin/chromedriver
 
 # https://community.sonarsource.com/t/no-usable-version-of-the-libssl-was-found/40941/4
+RUN apt-get install -y libssl-dev
+RUN export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 RUN echo "Installing dotnet 2.2" \
   && set -x \
   && wget --no-verbose -O /tmp/dotnet.tar.gz https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-linux-x64.tar.gz \

--- a/its/docker/Dockerfile
+++ b/its/docker/Dockerfile
@@ -3,7 +3,7 @@
 # during the QA task.
 #
 # Build from the basedir:
-#   docker build -f its/docker/Dockerfile -t sonar-scanner-jenkins-qa its/docker
+#   docker build -f its/docker/Dockerfile -t sonar-scanner-jenkins-qa .
 #
 # Verify the content of the image by running a shell session in it:
 #   docker run -it sonar-scanner-jenkins-qa bash
@@ -29,7 +29,7 @@ RUN apt-get install -y nodejs
 #==============================================================================
 # Google Chrome, for integration tests
 #==============================================================================
-ARG CHROME_VERSION=85.0.4183.102-1
+ARG CHROME_VERSION=105.0.5195.125-1
 RUN echo "Using Chrome version: $CHROME_VERSION" \
   && wget --no-verbose -O /tmp/chrome_amd64.deb http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
   # Ignore install errors; we will try and fix them below.
@@ -50,9 +50,9 @@ RUN INSTALLED_CHROME_VERSION=$(apt-cache policy google-chrome-stable | grep Inst
   && mv /opt/selenium/chromedriver /usr/bin/chromedriver \
   && chmod 755 /usr/bin/chromedriver
 
-RUN echo "Installing dotnet 2.2" \
+RUN echo "Installing dotnet 3.1.423" \
   && set -x \
-  && wget --no-verbose -O /tmp/dotnet.tar.gz https://download.visualstudio.microsoft.com/download/pr/228832ea-805f-45ab-8c88-fa36165701b9/16ce29a06031eeb09058dee94d6f5330/dotnet-sdk-2.2.401-linux-x64.tar.gz \
+  && wget --no-verbose -O /tmp/dotnet.tar.gz https://download.visualstudio.microsoft.com/download/pr/e137cdac-0e15-46ec-bd60-14fe6ad50c41/30c102677cc4bd0f117cc026781ec5e8/dotnet-sdk-3.1.423-linux-x64.tar.gz \
   && mkdir -p /usr/share/dotnet/ \
   && tar zxf /tmp/dotnet.tar.gz -C /usr/share/dotnet/ && rm /tmp/dotnet.tar.gz \
   && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
@@ -61,3 +61,4 @@ RUN echo "Installing dotnet 2.2" \
 RUN dotnet --info
 
 USER sonarsource
+

--- a/its/docker/Dockerfile
+++ b/its/docker/Dockerfile
@@ -50,9 +50,10 @@ RUN INSTALLED_CHROME_VERSION=$(apt-cache policy google-chrome-stable | grep Inst
   && mv /opt/selenium/chromedriver /usr/bin/chromedriver \
   && chmod 755 /usr/bin/chromedriver
 
-RUN echo "Installing dotnet 3.1.423" \
+# https://community.sonarsource.com/t/no-usable-version-of-the-libssl-was-found/40941/4
+RUN echo "Installing dotnet 2.2" \
   && set -x \
-  && wget --no-verbose -O /tmp/dotnet.tar.gz https://download.visualstudio.microsoft.com/download/pr/e137cdac-0e15-46ec-bd60-14fe6ad50c41/30c102677cc4bd0f117cc026781ec5e8/dotnet-sdk-3.1.423-linux-x64.tar.gz \
+  && wget --no-verbose -O /tmp/dotnet.tar.gz https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-linux-x64.tar.gz \
   && mkdir -p /usr/share/dotnet/ \
   && tar zxf /tmp/dotnet.tar.gz -C /usr/share/dotnet/ && rm /tmp/dotnet.tar.gz \
   && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \

--- a/its/docker/Dockerfile
+++ b/its/docker/Dockerfile
@@ -52,10 +52,9 @@ RUN INSTALLED_CHROME_VERSION=$(apt-cache policy google-chrome-stable | grep Inst
 
 # https://community.sonarsource.com/t/no-usable-version-of-the-libssl-was-found/40941/4
 RUN apt-get install -y libssl-dev
-RUN export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 RUN echo "Installing dotnet 2.2" \
   && set -x \
-  && wget --no-verbose -O /tmp/dotnet.tar.gz https://download.microsoft.com/download/f/c/1/fc16c864-b374-4668-83a2-f9f880928b2d/dotnet-sdk-2.1.202-linux-x64.tar.gz \
+  && wget --no-verbose -O /tmp/dotnet.tar.gz https://download.visualstudio.microsoft.com/download/pr/42f39f2f-3f24-4340-8c57-0a3133620c21/0a353696275b00cbddc9f60069867cfc/dotnet-sdk-2.2.110-linux-x64.tar.gz \
   && mkdir -p /usr/share/dotnet/ \
   && tar zxf /tmp/dotnet.tar.gz -C /usr/share/dotnet/ && rm /tmp/dotnet.tar.gz \
   && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \


### PR DESCRIPTION
We bumped the chrome version (the current version used in not available anymore) as well as the .NET version (that will reach EOL [next November](https://dotnet.microsoft.com/static/images/release-schedule.png?v=BDyL62yNwuz6N2VtA0k0V2uyjWl_oaDcx_VRuEBY2Ys))