### PR TITLE
.NET < 6 requires OpenSSL 1 which is not installed by default on Ubuntu 22.04

### DIFF
--- a/its/docker/Dockerfile
+++ b/its/docker/Dockerfile
@@ -61,4 +61,10 @@ RUN echo "Installing dotnet 2.2" \
   && chmod 755 /usr/bin/dotnet
 RUN dotnet --info
 
+# https://github.com/dotnet/core/issues/7038#issuecomment-1110377345
+RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN rm libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+RUN apt-get install libicu70
+
 USER sonarsource


### PR DESCRIPTION
Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONARJNKNS) ticket available, please make your commits and pull request start with the ticket ID (SONARJNKNS-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
