### PR TITLE
SONARJNKNS-363 Remove version check

### DIFF
--- a/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
+++ b/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
@@ -19,23 +19,16 @@
  */
 package hudson.plugins.sonar.client;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import hudson.model.Run;
 import hudson.plugins.sonar.SonarInstallation;
 import hudson.plugins.sonar.client.WsClient.CETask;
 import hudson.plugins.sonar.utils.Logger;
-import hudson.plugins.sonar.utils.Version;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonarqube.ws.client.HttpException;
 
 public class SQProjectResolver {
-  @VisibleForTesting
-  static final Cache<String, Version> INSTANCE_VERSION_CACHE = Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();
   private final HttpClient client;
 
   public SQProjectResolver(HttpClient client) {
@@ -62,13 +55,6 @@ public class SQProjectResolver {
     try {
       String serverAuthenticationToken = inst.getServerAuthenticationToken(build);
       WsClient wsClient = new WsClient(client, serverUrl, serverAuthenticationToken);
-
-      Version version = INSTANCE_VERSION_CACHE.get(installationName, unused -> new Version(wsClient.getServerVersion()));
-
-      if (version.compareTo(new Version("5.6")) < 0) {
-        Logger.LOG.info(() -> "SQ < 5.6 is not supported");
-        return null;
-      }
 
       ProjectInformation projectInfo = new ProjectInformation();
       projectInfo.setUrl(projectDashboardUrl);


### PR DESCRIPTION
Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:



- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make

We are experiencing multiple hangs of our Jenkins instance a day recently, it happens when people visit a build page and the build refuses to load, eventually so many threads get blocked up that Jenkins restarts.

I took thread dumps which are attached below, uploading them to fastthread.io showed 90 threads blocked on:

[performanceData.7.output.tar.gz](https://github.com/SonarSource/sonar-scanner-jenkins/files/12261847/performanceData.7.output.tar.gz)

```
java.lang.Thread.State: BLOCKED (on object monitor)
at java.util.concurrent.ConcurrentHashMap.compute(java.base@11.0.20/ConcurrentHashMap.java:1923)
- waiting to lock <0x000000048cc315d0> (a java.util.concurrent.ConcurrentHashMap$Node)
at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2683)
at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2666)
at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:112)
at com.github.benmanes.caffeine.cache.LocalManualCache.get(LocalManualCache.java:62)
at hudson.plugins.sonar.client.SQProjectResolver.resolve(SQProjectResolver.java:66)
at hudson.plugins.sonar.action.SonarCacheAction.get(SonarCacheAction.java:76)
at hudson.plugins.sonar.action.SonarCacheAction.get(SonarCacheAction.java:52)
at hudson.plugins.sonar.action.SonarProjectActionFactory.createProjectPage(SonarProjectActionFactory.java:118)
at hudson.plugins.sonar.action.SonarProjectActionFactory.createFor(SonarProjectActionFactory.java:84)
at hudson.plugins.sonar.action.SonarProjectActionFactory.createFor(SonarProjectActionFactory.java:43)
at hudson.model.Actionable.createFor(Actionable.java:115)
at hudson.model.Actionable.getAction(Actionable.java:332)
at io.jenkins.blueocean.rest.impl.pipeline.PrimaryBranch.lambda$resolve$0(PrimaryBranch.java:20)
at io.jenkins.blueocean.rest.impl.pipeline.PrimaryBranch$$Lambda$2429/0x0000000802c10440.test(Unknown Source)
```

The sonar instance we use is https://sonarcloud.io

I don't know if this will fix the root cause or if it will just fail later on but I plan to upload this change to our system and see if it helps. This checks seems to be no longer needed as it's checking for an ancient version, what do you think?

Otherwise I'd suggest adding in some timeouts instead if the sonar is unresponsive


- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [x] If there is a [JIRA](http://jira.sonarsource.com/browse/SONARJNKNS) ticket available, please make your commits and pull request start with the ticket ID (SONARJNKNS-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
