### PR TITLE
Save webhook results in action

### DIFF
--- a/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
+++ b/src/main/java/hudson/plugins/sonar/client/SQProjectResolver.java
@@ -52,6 +52,12 @@ public class SQProjectResolver {
       return null;
     }
 
+    // provided by SonarQubeWebHook
+    ProjectInformation action = build.getAction(ProjectInformation.class);
+    if (action != null) {
+      return action;
+    }
+
     try {
       String serverAuthenticationToken = inst.getServerAuthenticationToken(build);
       WsClient wsClient = new WsClient(client, serverUrl, serverAuthenticationToken);

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHook.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHook.java
@@ -133,13 +133,18 @@ public class SonarQubeWebHook implements UnprotectedRootAction {
 
     private final String payloadAsString;
     private final String taskId;
+    private final String componentName;
     private final String taskStatus;
     private final String qualityGateStatus;
+    private final String dashboardUrl;
 
     Payload(String payloadAsString, JSONObject json) {
       this.payloadAsString = payloadAsString;
       this.taskId = json.getString("taskId");
       this.taskStatus = json.getString("status");
+      JSONObject project = json.getJSONObject("project");
+      this.componentName = project.getString("name");
+      this.dashboardUrl = project.getString("url");
       if (CETask.STATUS_SUCCESS.equals(getTaskStatus())) {
         this.qualityGateStatus = json.has("qualityGate") ? json.getJSONObject("qualityGate").getString("status") : "NONE";
       } else {
@@ -157,6 +162,14 @@ public class SonarQubeWebHook implements UnprotectedRootAction {
 
     String getQualityGateStatus() {
       return qualityGateStatus;
+    }
+
+    String getComponentName() {
+      return componentName;
+    }
+
+    String getDashboardUrl() {
+      return dashboardUrl;
     }
 
     String getPayloadAsString() {

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStep.java
@@ -37,6 +37,7 @@ import hudson.plugins.sonar.SonarInstallation;
 import hudson.plugins.sonar.action.SonarAnalysisAction;
 import hudson.plugins.sonar.client.HttpClient;
 import hudson.plugins.sonar.client.OkHttpClientSingleton;
+import hudson.plugins.sonar.client.ProjectInformation;
 import hudson.plugins.sonar.client.WsClient;
 import hudson.plugins.sonar.utils.SonarUtils;
 import hudson.security.ACL;
@@ -47,6 +48,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -163,6 +165,7 @@ public class WaitForQualityGateStep extends Step implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private WaitForQualityGateStep step;
+    String dashboardUrl;
 
     public Execution(WaitForQualityGateStep step, StepContext context) {
       super(context);
@@ -207,6 +210,7 @@ public class WaitForQualityGateStep extends Step implements Serializable {
         if (ceTaskId != null) {
           serverUrl = a.getInstallationUrl();
           installationName = a.getInstallationName();
+          dashboardUrl = a.getUrl();
           credentialsId = a.getCredentialsId();
           break;
         }
@@ -238,10 +242,21 @@ public class WaitForQualityGateStep extends Step implements Serializable {
       WsClient wsClient = new WsClient(new HttpClient(OkHttpClientSingleton.getInstance()),
         step.getServerUrl(), SonarUtils.getAuthenticationToken(getContextClass(Run.class), inst, step.credentialsId));
       WsClient.CETask ceTask = wsClient.getCETask(step.getTaskId());
-      return checkQualityGate(ceTask.getStatus(), () -> wsClient.requestQualityGateStatus(ceTask.getAnalysisId()), true);
+
+      ProjectInformation projectInformation = new ProjectInformation();
+      projectInformation.setUrl(dashboardUrl);
+
+      projectInformation.setCeStatus(ceTask.getStatus());
+      projectInformation.setCeUrl(ceTask.getUrl());
+      projectInformation.setName(ceTask.getComponentName());
+
+      return checkQualityGate(projectInformation, () -> wsClient.requestQualityGateStatus(ceTask.getAnalysisId()), true);
     }
 
-    private void handleQGStatus(String status) {
+    private void handleQGStatus(ProjectInformation projectInformation) {
+      getContextClass(Run.class).addAction(projectInformation);
+
+      String status = projectInformation.getStatus();
       if (step.isAbortPipeline() && !"OK".equals(status)) {
         getContext().onFailure(new AbortException("Pipeline aborted due to quality gate failure: " + status));
       } else {
@@ -282,18 +297,28 @@ public class WaitForQualityGateStep extends Step implements Serializable {
     private void validateWebhookAndCheckQualityGateIfValid(SonarQubeWebHook.WebhookEvent event, boolean onStart) {
       SonarQubeWebHook.get().removeListener(this);
       if (validateWebhook(event)) {
+        ProjectInformation projectInformation = new ProjectInformation();
+        SonarQubeWebHook.Payload payload = event.getPayload();
+        projectInformation.setCeStatus(payload.getTaskStatus());
+        projectInformation.setUrl(dashboardUrl);
+        projectInformation.setName(payload.getComponentName());
+
         // only execute the checkQualityGate if the webhook is found to be valid (getContext().onFailure() does not interrupt execution)
-        checkQualityGate(event.getPayload().getTaskStatus(), event.getPayload()::getQualityGateStatus, onStart);
+        checkQualityGate(projectInformation, payload::getQualityGateStatus, onStart);
       }
     }
 
-    private boolean checkQualityGate(String taskStatus, Supplier<String> qgStatusSupplier, boolean onStart) {
+    private boolean checkQualityGate(ProjectInformation projectInformation, Supplier<String> qgStatusSupplier, boolean onStart) {
+      String taskStatus = projectInformation.getCeStatus().toUpperCase(Locale.US);
       log("SonarQube task '%s' status is '%s'", step.taskId, taskStatus);
       switch (taskStatus) {
         case WsClient.CETask.STATUS_SUCCESS:
-          String qgstatus = qgStatusSupplier.get();
-          log("SonarQube task '%s' completed. Quality gate is '%s'", step.taskId, qgstatus);
-          handleQGStatus(qgstatus);
+          String qualityGateStatus = qgStatusSupplier.get();
+
+          projectInformation.setStatus(qualityGateStatus);
+
+          log("SonarQube task '%s' completed. Quality gate is '%s'", step.taskId, qualityGateStatus);
+          handleQGStatus(projectInformation);
           return true;
         case WsClient.CETask.STATUS_FAILURE:
         case WsClient.CETask.STATUS_CANCELED:

--- a/src/test/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookTest.java
+++ b/src/test/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookTest.java
@@ -56,7 +56,8 @@ public class SonarQubeWebHookTest {
     jenkins.postJSON("sonarqube-webhook/", "{\n" +
       "\"taskId\":\"AVpBJY0hh5C8Sya1ZSgH\",\n" +
       "\"status\":\"SUCCESS\",\n" +
-      "\"qualityGate\":{\"status\":\"OK\"}\n" +
+      "\"qualityGate\":{\"status\":\"OK\"},\n" +
+      "\"project\": {\"name\": \"foo\", \"url\": \"http://localhost:9000/dashboard?id=foo\"}\n" +
       "}");
 
     SonarQubeWebHook.get().addListener(
@@ -67,7 +68,8 @@ public class SonarQubeWebHookTest {
     jenkins.postJSON("sonarqube-webhook/", "{\n" +
       "\"taskId\":\"AVpBJY0hh5C8Sya1ZSgH\",\n" +
       "\"status\":\"SUCCESS\",\n" +
-      "\"qualityGate\":{\"status\":\"OK\"}\n" +
+      "\"qualityGate\":{\"status\":\"OK\"},\n" +
+      "\"project\": {\"name\": \"foo\", \"url\": \"http://localhost:9000/dashboard?id=foo\"}\n" +
       "}");
 
     assertThat(eventsPerListener).containsOnly(entry("ListenerA", "AVpBJY0hh5C8Sya1ZSgHSUCCESSOK"),
@@ -79,6 +81,7 @@ public class SonarQubeWebHookTest {
     jenkins.postJSON("sonarqube-webhook/", "{\n" +
       "\"taskId\":\"AVpBJY0hh5C8Sya1ZSgH\",\n" +
       "\"status\":\"SUCCESS\",\n" +
+     "\"project\": {\"name\": \"foo\", \"url\": \"http://localhost:9000/dashboard?id=foo\"}\n" +
       "}");
 
     assertThat(eventsPerListener).containsOnly(entry("ListenerA", "AVpBJY0hh5C8Sya1ZSgHSUCCESSNONE"),

--- a/src/test/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStepTest.java
+++ b/src/test/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStepTest.java
@@ -416,7 +416,8 @@ public class WaitForQualityGateStepTest {
     String payload = "{\n" +
       "\"taskId\":\"" + taskId + "\",\n" +
       "\"status\":\"" + endTaskStatus + "\",\n" +
-      "\"qualityGate\":{\"status\":\"" + qgStatus + "\"}\n" +
+      "\"qualityGate\":{\"status\":\"" + qgStatus + "\"},\n" +
+      "\"project\": {\"name\": \"foo\", \"url\": \"http://localhost:9000/dashboard?id=foo\"}\n" +
       "}";
     OkHttpClient client = new OkHttpClient();
     Request req = new Request.Builder()
@@ -437,7 +438,8 @@ public class WaitForQualityGateStepTest {
     String payload = "{\n" +
       "\"taskId\":\"" + taskId + "\",\n" +
       "\"status\":\"" + endTaskStatus + "\",\n" +
-      "\"qualityGate\":{\"status\":\"" + qgStatus + "\"}\n" +
+      "\"qualityGate\":{\"status\":\"" + qgStatus + "\"},\n" +
+      "\"project\": {\"name\": \"foo\", \"url\": \"http://localhost:9000/dashboard?id=foo\"}\n" +
       "}";
 
     Request req = new Request.Builder()


### PR DESCRIPTION
Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make

We are experiencing multiple hangs of our Jenkins instance a day recently, it happens when people visit a build page and the build refuses to load, eventually so many threads get blocked up that Jenkins restarts.

I took thread dumps which are attached below, uploading them to fastthread.io showed 90 threads blocked on:

[performanceData.7.output.tar.gz](https://github.com/SonarSource/sonar-scanner-jenkins/files/12261847/performanceData.7.output.tar.gz)

```
java.lang.Thread.State: BLOCKED (on object monitor)
at java.util.concurrent.ConcurrentHashMap.compute(java.base@11.0.20/ConcurrentHashMap.java:1923)
- waiting to lock <0x000000048cc315d0> (a java.util.concurrent.ConcurrentHashMap$Node)
at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2683)
at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2666)
at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:112)
at com.github.benmanes.caffeine.cache.LocalManualCache.get(LocalManualCache.java:62)
at hudson.plugins.sonar.client.SQProjectResolver.resolve(SQProjectResolver.java:66)
at hudson.plugins.sonar.action.SonarCacheAction.get(SonarCacheAction.java:76)
at hudson.plugins.sonar.action.SonarCacheAction.get(SonarCacheAction.java:52)
at hudson.plugins.sonar.action.SonarProjectActionFactory.createProjectPage(SonarProjectActionFactory.java:118)
at hudson.plugins.sonar.action.SonarProjectActionFactory.createFor(SonarProjectActionFactory.java:84)
at hudson.plugins.sonar.action.SonarProjectActionFactory.createFor(SonarProjectActionFactory.java:43)
at hudson.model.Actionable.createFor(Actionable.java:115)
at hudson.model.Actionable.getAction(Actionable.java:332)
at io.jenkins.blueocean.rest.impl.pipeline.PrimaryBranch.lambda$resolve$0(PrimaryBranch.java:20)
at io.jenkins.blueocean.rest.impl.pipeline.PrimaryBranch$$Lambda$2429/0x0000000802c10440.test(Unknown Source)
```

The sonar instance we use is https://sonarcloud.io

This change passes along the information from the Sonar webhook to be stored in the run so that information doesn't need to be fetched from sonar when people try and load a build or project page.

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONARJNKNS) ticket available, please make your commits and pull request start with the ticket ID (SONARJNKNS-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
