### PR TITLE
SONARJNKNS-361 Configuration setting to use sonar.token

### DIFF
--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerBegin.java
@@ -44,6 +44,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
+import static hudson.plugins.sonar.SonarInstallation.PROPERTY_SONAR_LOGIN;
+import static hudson.plugins.sonar.SonarInstallation.PROPERTY_SONAR_TOKEN;
+
 public class MsBuildSQRunnerBegin extends AbstractMsBuildSQRunner {
 
   /**
@@ -110,7 +113,7 @@ public class MsBuildSQRunnerBegin extends AbstractMsBuildSQRunner {
     map.put("sonar.host.url", inst.getServerUrl());
     String token = inst.getServerAuthenticationToken(run);
     if (!StringUtils.isBlank(token)) {
-      map.put("sonar.login", token);
+      map.put(inst.getTokenPropertyName(), token);
     }
 
     return map;
@@ -129,7 +132,7 @@ public class MsBuildSQRunnerBegin extends AbstractMsBuildSQRunner {
     for (Map.Entry<String, String> e : props.entrySet()) {
       if (!StringUtils.isEmpty(e.getValue())) {
         // expand macros using environment variables and hide token
-        boolean hide = e.getKey().contains("sonar.login");
+        boolean hide = e.getKey().contains(PROPERTY_SONAR_LOGIN) || e.getKey().contains(PROPERTY_SONAR_TOKEN);
         args.addKeyValuePair("/d:", e.getKey(), env.expand(e.getValue()), hide);
       }
     }

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerEnd.java
@@ -41,6 +41,9 @@ import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import static hudson.plugins.sonar.SonarInstallation.PROPERTY_SONAR_LOGIN;
+import static hudson.plugins.sonar.SonarInstallation.PROPERTY_SONAR_TOKEN;
+
 public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
   @DataBoundConstructor
   public MsBuildSQRunnerEnd() {
@@ -91,7 +94,7 @@ public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
     for (Map.Entry<String, String> e : props.entrySet()) {
       if (!StringUtils.isEmpty(e.getValue())) {
         // expand macros using environment variables and hide token
-        boolean hide = e.getKey().contains("sonar.login");
+        boolean hide = e.getKey().contains(PROPERTY_SONAR_LOGIN) || e.getKey().contains(PROPERTY_SONAR_TOKEN);
         args.addKeyValuePair("/d:", e.getKey(), env.expand(e.getValue()), hide);
       }
     }
@@ -104,7 +107,7 @@ public class MsBuildSQRunnerEnd extends AbstractMsBuildSQRunner {
 
     String token = inst.getServerAuthenticationToken(run);
     if (!StringUtils.isBlank(token)) {
-      map.put("sonar.login", token);
+      map.put(inst.getTokenPropertyName(), token);
     }
 
     return map;

--- a/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
@@ -146,7 +146,7 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
     StringBuilder sb = new StringBuilder();
     sb.append("{ \"sonar.host.url\" : \"").append(escapeJson(hostUrl)).append("\"");
     if (!token.isEmpty()) {
-      sb.append(", \"sonar.login\" : \"").append(escapeJson(token)).append("\"");
+      sb.append(", \"").append(inst.getTokenPropertyName()).append("\" : \"").append(escapeJson(token)).append("\"");
     }
     String additionalAnalysisProperties = inst.getAdditionalAnalysisProperties();
     if (additionalAnalysisProperties != null) {

--- a/src/main/java/hudson/plugins/sonar/SonarInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/SonarInstallation.java
@@ -35,6 +35,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class SonarInstallation implements Serializable {
 
   private static final long serialVersionUID = 1L;
+  static final String PROPERTY_SONAR_TOKEN = "sonar.token";
+  static final String PROPERTY_SONAR_LOGIN = "sonar.login";
 
   private final String name;
   private final String serverUrl;
@@ -69,6 +71,8 @@ public class SonarInstallation implements Serializable {
 
   private String[] split;
 
+  private final boolean useTokenProperty;
+
   /**
    * Maintained to retain compatibility
    * @deprecated since 2.9
@@ -79,7 +83,7 @@ public class SonarInstallation implements Serializable {
     String mojoVersion, String additionalProperties, TriggersConfig triggers,
     String additionalAnalysisProperties) {
     this(name, serverUrl, null, Secret.fromString(StringUtils.trimToNull(serverAuthenticationToken)), null,
-      mojoVersion, additionalProperties, additionalAnalysisProperties, triggers);
+      mojoVersion, additionalProperties, additionalAnalysisProperties, triggers, false);
   }
 
   @DataBoundConstructor
@@ -92,7 +96,8 @@ public class SonarInstallation implements Serializable {
     @CheckForNull String mojoVersion,
     @CheckForNull String additionalProperties,
     @CheckForNull String additionalAnalysisProperties,
-    @CheckForNull TriggersConfig triggers) {
+    @CheckForNull TriggersConfig triggers,
+    boolean useTokenProperty) {
     this.name = name;
     this.serverUrl = serverUrl;
     this.credentialsId = credentialsId;
@@ -102,6 +107,7 @@ public class SonarInstallation implements Serializable {
     this.mojoVersion = mojoVersion;
     this.additionalProperties = additionalProperties;
     this.triggers = triggers;
+    this.useTokenProperty = useTokenProperty;
   }
 
   /**
@@ -254,6 +260,14 @@ public class SonarInstallation implements Serializable {
       triggers = new TriggersConfig();
     }
     return triggers;
+  }
+
+  public boolean useTokenProperty() {
+    return useTokenProperty;
+  }
+
+  public String getTokenPropertyName() {
+    return useTokenProperty() ? PROPERTY_SONAR_TOKEN : PROPERTY_SONAR_LOGIN;
   }
 
   @SuppressWarnings("deprecation")

--- a/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
+++ b/src/main/java/hudson/plugins/sonar/SonarRunnerBuilder.java
@@ -43,6 +43,7 @@ import hudson.plugins.sonar.utils.SonarUtils;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.ArgumentListBuilder;
+import io.jenkins.cli.shaded.org.apache.sshd.core.CoreModuleProperties;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Map.Entry;
@@ -363,7 +364,7 @@ public class SonarRunnerBuilder extends Builder {
       args.append("sonar.host.url", si.getServerUrl());
       String token = si.getServerAuthenticationToken(build);
       if (StringUtils.isNotBlank(token)) {
-        args.appendMasked("sonar.login", token);
+        args.appendMasked(si.getTokenPropertyName(), token);
       }
     }
 

--- a/src/main/java/hudson/plugins/sonar/utils/SonarMaven.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarMaven.java
@@ -97,7 +97,7 @@ public final class SonarMaven extends Maven {
 
     String token = getInstallation().getServerAuthenticationToken(build);
     if (StringUtils.isNotBlank(token)) {
-      argsBuilder.appendMasked("sonar.login", token);
+      argsBuilder.appendMasked(getInstallation().getTokenPropertyName(), token);
     }
 
     if (build instanceof MavenModuleSetBuild) {

--- a/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
@@ -24,6 +24,10 @@
           </f:entry>
 
           <f:advanced>
+            <f:entry title="${%TokenProperty}" description="${%TokenPropertyDesc}">
+              <f:checkbox name="sonar.useTokenProperty" checked="${inst.useTokenProperty()}"/>
+            </f:entry>
+
             <f:entry title="${%MojoVersion}" description="${%MojoVersionDescr}">
               <f:textbox name="sonar.mojoVersion" value="${inst.getMojoVersion()}"/>
             </f:entry>

--- a/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.properties
+++ b/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.properties
@@ -21,3 +21,5 @@ InjectVars=Enable injection of SonarQube server configuration as build environme
 InjectVarsTitle=Environment variables
 InjectVarsDesc= If checked, job administrators will be able to inject a SonarQube server configuration as environment variables in the build.
 WebhookSecret=Webhook Secret
+TokenProperty=Use sonar.token instead of sonar.login
+TokenPropertyDesc=Prevent the analysis warning for SonarQube versions >= 10.0

--- a/src/test/java/hudson/plugins/sonar/BaseTest.java
+++ b/src/test/java/hudson/plugins/sonar/BaseTest.java
@@ -123,7 +123,7 @@ public class BaseTest extends SonarTestCase {
     SonarInstallation installation = spy(new SonarInstallation(
             SONAR_INSTALLATION_NAME,
             SONAR_HOST,
-            "token", null, null, null, null, null, null));
+            "token", null, null, null, null, null, null, false));
     addCredential("token", "secret");
     configureSonar(installation);
   }

--- a/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerBeginTest.java
+++ b/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerBeginTest.java
@@ -77,7 +77,7 @@ public class MsBuildSQRunnerBeginTest extends MsBuildSQRunnerTest {
   @Test
   public void additionalArgs() throws Exception {
     SonarInstallation inst = new SonarInstallation("default", null,
-      null, null, null, null, "/x:a=b", "key=value", null);
+      null, null, null, null, "/x:a=b", "key=value", null, false);
     configureSonar(inst);
     configureMsBuildScanner(true);
 
@@ -91,7 +91,7 @@ public class MsBuildSQRunnerBeginTest extends MsBuildSQRunnerTest {
   @Test
   public void testSonarProps() throws Exception {
     SonarInstallation inst = spy(new SonarInstallation("default", "http://dummy-server:9090", "credentialsId", null,
-      null, null, null, null, null));
+      null, null, null, null, null, false));
     configureSonar(inst);
     addCredential("credentialsId", "any-token");
     configureMsBuildScanner(false);

--- a/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerEndTest.java
+++ b/src/test/java/hudson/plugins/sonar/MsBuildSQRunnerEndTest.java
@@ -33,7 +33,7 @@ public class MsBuildSQRunnerEndTest extends MsBuildSQRunnerTest {
 
   @Test
   public void testToken() throws Exception {
-    SonarInstallation inst = spy(new SonarInstallation(SONAR_INSTALLATION_NAME, "localhost", "credentialsId", null,null, null, null, null, null));
+    SonarInstallation inst = spy(new SonarInstallation(SONAR_INSTALLATION_NAME, "localhost", "credentialsId", null,null, null, null, null, null, false));
     addCredential("credentialsId", "token");
     configureSonar(inst);
     configureMsBuildScanner(false);

--- a/src/test/java/hudson/plugins/sonar/SonarBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarBuildWrapperTest.java
@@ -106,7 +106,7 @@ public class SonarBuildWrapperTest extends SonarTestCase {
   public void maskAuthToken() throws IOException, InterruptedException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     SonarInstallation inst = spy(new SonarInstallation("local", "http://localhost:9001", CREDENTIALSID, null, null, null, null,
-      null, new TriggersConfig()));
+      null, new TriggersConfig(), false));
     addCredential(CREDENTIALSID, MYTOKEN);
     configureSonar(inst);
 
@@ -138,7 +138,7 @@ public class SonarBuildWrapperTest extends SonarTestCase {
 
   @Test
   public void testEnvironmentMojoVersion() {
-    installation = new SonarInstallation(null, null, null, null, null, "2.0", null, null, null);
+    installation = new SonarInstallation(null, null, null, null, null, "2.0", null, null, null, false);
 
     Map<String, String> map = SonarBuildWrapper.createVars(installation, null, new EnvVars(), mock(Run.class));
 
@@ -272,14 +272,14 @@ public class SonarBuildWrapperTest extends SonarTestCase {
     addCredential(CREDENTIALSID, MYTOKEN);
 
     return new SonarInstallation("local", "http://localhost:9001", CREDENTIALSID, null, null, null,
-      "-X", "key=value", new TriggersConfig());
+      "-X", "key=value", new TriggersConfig(), false);
   }
 
   private SonarInstallation createTestInstallationForEnv() {
     addCredential(CREDENTIALSID, MYTOKEN);
 
     return new SonarInstallation("local", "http://$MY_SERVER:$MY_PORT", CREDENTIALSID, null, null, null,
-      "-X", "key=$MY_VALUE", new TriggersConfig());
+      "-X", "key=$MY_VALUE", new TriggersConfig(), false);
   }
 
 }

--- a/src/test/java/hudson/plugins/sonar/SonarGlobalConfigurationTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarGlobalConfigurationTest.java
@@ -60,7 +60,7 @@ public class SonarGlobalConfigurationTest extends SonarTestCase {
   }
 
   private static SonarInstallation createInstallation(String name) {
-    return new SonarInstallation(name, null, null,null, null, null, null, null, null);
+    return new SonarInstallation(name, null, null,null, null, null, null, null, null, false);
   }
 
   @Test

--- a/src/test/java/hudson/plugins/sonar/SonarInstallationTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarInstallationTest.java
@@ -31,6 +31,8 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.Test;
 
+import static hudson.plugins.sonar.SonarInstallation.PROPERTY_SONAR_LOGIN;
+import static hudson.plugins.sonar.SonarInstallation.PROPERTY_SONAR_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -55,7 +57,8 @@ public class SonarInstallationTest extends SonarTestCase {
       "mojoVersion",
       "props",
       "key=value",
-      triggers));
+      triggers,
+      false));
     StringCredentials cred = new StringCredentialsImpl(CredentialsScope.GLOBAL, "an-id", null, Secret.fromString("token"));
     doReturn(cred).when(inst).getCredentials(any(Run.class));
     d.setInstallations(inst);
@@ -122,12 +125,24 @@ public class SonarInstallationTest extends SonarTestCase {
   }
 
   private void assertAnalysisPropsWindows(String input, String... expectedEntries) {
-    SonarInstallation inst = new SonarInstallation(null, null, null, null, null, null, null, input, null);
+    SonarInstallation inst = new SonarInstallation(null, null, null, null, null, null, null, input, null, false);
     assertThat(inst.getAdditionalAnalysisPropertiesWindows()).isEqualTo(expectedEntries);
   }
 
   private void assertAnalysisPropsUnix(String input, String... expectedEntries) {
-    SonarInstallation inst = new SonarInstallation(null, null, null, null, null, null, null, input, null);
+    SonarInstallation inst = new SonarInstallation(null, null, null, null, null, null, null, input, null, false);
     assertThat(inst.getAdditionalAnalysisPropertiesUnix()).isEqualTo(expectedEntries);
+  }
+
+  @Test
+  public void getTokenPropertyName_whenUseTokenProperty_shouldReturnSonarToken() {
+    SonarInstallation inst = new SonarInstallation(null, null, null, null, null, null, null, null, null, true);
+    assertThat(inst.getTokenPropertyName()).isEqualTo(PROPERTY_SONAR_TOKEN);
+  }
+
+  @Test
+  public void getTokenPropertyName_whenNotUseTokenProperty_shouldReturnSonarLogin() {
+    SonarInstallation inst = new SonarInstallation(null, null, null, null, null, null, null, null, null, false);
+    assertThat(inst.getTokenPropertyName()).isEqualTo(PROPERTY_SONAR_LOGIN);
   }
 }

--- a/src/test/java/hudson/plugins/sonar/SonarRunnerBuilderTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarRunnerBuilderTest.java
@@ -93,7 +93,7 @@ public class SonarRunnerBuilderTest extends SonarTestCase {
   @Test
   public void additionalArgs() {
     ArgumentListBuilder args = new ArgumentListBuilder();
-    SonarInstallation inst = new SonarInstallation(null, null, null, null, null, null, "-Y", "key=value", null);
+    SonarInstallation inst = new SonarInstallation(null, null, null, null, null, null, "-Y", "key=value", null, false);
     SonarRunnerBuilder builder = new SonarRunnerBuilder(null, null, "myCustomProjectSettings.properties", null, null, null, null, "-X -e");
     builder.addAdditionalArguments(args, inst);
     assertThat(args.toString()).isEqualTo("-Y -Dkey=value -X -e");
@@ -132,12 +132,14 @@ public class SonarRunnerBuilderTest extends SonarTestCase {
     SonarInstallation installation = mock(SonarInstallation.class);
     when(installation.getServerUrl()).thenReturn("hostUrl");
     when(installation.getServerAuthenticationToken(any(Run.class))).thenReturn("token");
+    when(installation.useTokenProperty()).thenReturn(true);
+    when(installation.getTokenPropertyName()).thenCallRealMethod();
 
     SonarRunnerBuilder builder = new SonarRunnerBuilder(null, null, null, null, null, null, null, null);
     builder.populateConfiguration(argsBuilder, build, build.getWorkspace(), listener, env, installation);
 
     assertThat(args.toStringWithQuote())
-      .contains("-Dsonar.login=token");
+      .contains("-Dsonar.token=token");
   }
 
   /**

--- a/src/test/java/hudson/plugins/sonar/SonarTestCase.java
+++ b/src/test/java/hudson/plugins/sonar/SonarTestCase.java
@@ -90,7 +90,7 @@ public abstract class SonarTestCase {
   }
 
   protected SonarInstallation configureDefaultSonar() {
-    return configureSonar(new SonarInstallation(SONAR_INSTALLATION_NAME, null, null, null, null, null, null, null, null));
+    return configureSonar(new SonarInstallation(SONAR_INSTALLATION_NAME, null, null, null, null, null, null, null, null, false));
   }
 
   protected SonarInstallation configureSonar(SonarInstallation sonarInstallation) {

--- a/src/test/java/hudson/plugins/sonar/casc/CasCMinimalTest.java
+++ b/src/test/java/hudson/plugins/sonar/casc/CasCMinimalTest.java
@@ -40,6 +40,7 @@ public class CasCMinimalTest extends RoundTripAbstractTest {
     assertThat(installation).isNotNull();
     assertThat(installation.getName()).isEqualTo("TEST");
     assertThat(installation.getServerUrl()).isEqualTo("http://url:9000");
+    assertThat(installation.useTokenProperty()).isEqualTo(true);
   }
 
   SonarInstallation getSonarInstallation() {

--- a/src/test/java/hudson/plugins/sonar/client/SQProjectResolverTest.java
+++ b/src/test/java/hudson/plugins/sonar/client/SQProjectResolverTest.java
@@ -112,7 +112,7 @@ public class SQProjectResolverTest extends SonarTestCase {
   @Test
   public void testWsHttpNotFound() {
     SonarInstallation inst = spy(new SonarInstallation(testName.getMethodName(), SERVER_URL, CREDENTIAL_ID, null, null, null, null,
-      null, null));
+      null, null, false));
     addCredential(CREDENTIAL_ID, TOKEN);
     configureSonar(inst);
 
@@ -125,7 +125,7 @@ public class SQProjectResolverTest extends SonarTestCase {
   @Test
   public void testWsHttpError() {
     SonarInstallation inst = spy(new SonarInstallation(testName.getMethodName(), SERVER_URL, CREDENTIAL_ID, null, null, null, null,
-      null, null));
+      null, null, false));
     addCredential(CREDENTIAL_ID, TOKEN);
     configureSonar(inst);
 
@@ -174,7 +174,7 @@ public class SQProjectResolverTest extends SonarTestCase {
 
   @Override
   protected SonarInstallation configureDefaultSonar() {
-    return configureSonar(new SonarInstallation(testName.getMethodName(), null, null, null, null, null, null, null, null));
+    return configureSonar(new SonarInstallation(testName.getMethodName(), null, null, null, null, null, null, null, null, false));
   }
 
   private void mockSQServer(Exception toThrow) {
@@ -183,7 +183,7 @@ public class SQProjectResolverTest extends SonarTestCase {
 
   private void mockSQServer56() throws Exception {
     SonarInstallation inst = spy(new SonarInstallation(testName.getMethodName(), SERVER_URL, CREDENTIAL_ID, null, null, null, null,
-        null, null));
+        null, null, false));
     addCredential(CREDENTIAL_ID, TOKEN);
     configureSonar(inst);
 

--- a/src/test/java/hudson/plugins/sonar/utils/SonarMavenTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/SonarMavenTest.java
@@ -48,6 +48,8 @@ public class SonarMavenTest {
     SonarInstallation installation = mock(SonarInstallation.class);
     when(installation.getServerUrl()).thenReturn("hostUrl");
     when(installation.getServerAuthenticationToken(any(Run.class))).thenReturn("xyz");
+    when(installation.useTokenProperty()).thenReturn(true);
+    when(installation.getTokenPropertyName()).thenCallRealMethod();
     when(publisher.getInstallation()).thenReturn(installation);
     when(publisher.getBranch()).thenReturn("branch");
 
@@ -60,7 +62,7 @@ public class SonarMavenTest {
     assertThat(result).contains("-Dprop=value");
     assertThat(result).contains("-Dsonar.host.url=hostUrl");
     assertThat(result).contains("-Dsonar.branch=branch");
-    assertThat(result).contains("-Dsonar.login=xyz");
+    assertThat(result).contains("-Dsonar.token=xyz");
   }
 
   @Test

--- a/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
@@ -80,7 +80,7 @@ public class SonarUtilsTest {
     Run last = mockedRun(null, a1);
     Run r = mockedRun(last);
 
-    SonarInstallation sonarInstallation = new SonarInstallation("inst", null, "credentialsId", null, null, null, null, null, null);
+    SonarInstallation sonarInstallation = new SonarInstallation("inst", null, "credentialsId", null, null, null, null, null, null, false);
     SonarAnalysisAction action = SonarUtils.addBuildInfoFromLastBuildTo(r, mock(TaskListener.class), sonarInstallation, "credId", false);
 
     assertThat(action.getInstallationName()).isEqualTo("inst");
@@ -94,7 +94,7 @@ public class SonarUtilsTest {
   public void should_mark_build_as_unstable_when_java_warning_is_logged() throws Exception {
     Run r = mockedBuild("The version of Java (1.8.0_101) you have used to run this analysis is deprecated and we will stop accepting it from October 2020. Please update to at least Java 11.");
     FilePath workspace = new FilePath(new File("non_existing_file"));
-    SonarInstallation sonarInstallation = new SonarInstallation("inst", "https://url.com", "credentialsId", null, null, null, null, null, null);
+    SonarInstallation sonarInstallation = new SonarInstallation("inst", "https://url.com", "credentialsId", null, null, null, null, null, null, false);
     TaskListener listener = mock(TaskListener.class);
     PrintStream printStream = mock(PrintStream.class);
     when(listener.getLogger()).thenReturn(printStream);
@@ -109,7 +109,7 @@ public class SonarUtilsTest {
   public void should_not_mark_build_as_unstable_when_result_is_already_failed() throws Exception {
     Run r = mockedBuild("The version of Java (1.8.0_101) you have used to run this analysis is deprecated and we will stop accepting it from October 2020. Please update to at least Java 11.");
     FilePath workspace = new FilePath(new File("non_existing_file"));
-    SonarInstallation sonarInstallation = new SonarInstallation("inst", "https://url.com", "credentialsId", null, null, null, null, null, null);
+    SonarInstallation sonarInstallation = new SonarInstallation("inst", "https://url.com", "credentialsId", null, null, null, null, null, null, false);
     TaskListener listener = mock(TaskListener.class);
     PrintStream printStream = mock(PrintStream.class);
     when(listener.getLogger()).thenReturn(printStream);

--- a/src/test/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStepTest.java
+++ b/src/test/java/org/sonarsource/scanner/jenkins/pipeline/WaitForQualityGateStepTest.java
@@ -464,7 +464,7 @@ public class WaitForQualityGateStepTest {
     SonarQubeWebHook.get().listeners.clear();
     story.j.jenkins.getDescriptorByType(SonarGlobalConfiguration.class)
       .setInstallations(
-        new SonarInstallation(SONAR_INSTALLATION_NAME, "http://localhost:" + port + "/sonarqube", null, null, null, null, null, null, null));
+        new SonarInstallation(SONAR_INSTALLATION_NAME, "http://localhost:" + port + "/sonarqube", null, null, null, null, null, null, null, false));
     WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, JOB_NAME);
     // Use a fake serverUrl to validate that the installation url is used by the wait step
     String serverUrl = "http://sonarqube.example.com";

--- a/src/test/resources/hudson/plugins/sonar/casc/config-minimal.yaml
+++ b/src/test/resources/hudson/plugins/sonar/casc/config-minimal.yaml
@@ -5,3 +5,4 @@ unclassified:
       - name: "TEST"
         credentialsId: "test-id"
         serverUrl: "http://url:9000"
+        useTokenProperty: true

--- a/src/test/resources/hudson/plugins/sonar/casc/config-w-triggers.yaml
+++ b/src/test/resources/hudson/plugins/sonar/casc/config-w-triggers.yaml
@@ -5,6 +5,7 @@ unclassified:
       - name: "TEST"
         credentialsId: "test-id"
         serverUrl: "http://url:9000"
+        useTokenProperty: true
         triggers:
           skipScmCause: true
           skipUpstreamCause: true


### PR DESCRIPTION
Adds new setting in the SonarQube server configuration

![image](https://github.com/SonarSource/sonar-scanner-jenkins/assets/34447090/d17ab531-b368-4bd6-88a7-336e35311588)

The setting is disabled by default to not break configurations with SQ < 10.0.