### PR TITLE
SONARJNKNS-371 Migrate away from FGC promote function

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,9 +10,7 @@ env:
   ARTIFACTORY_DEPLOY_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer
   ARTIFACTORY_DEPLOY_PASSWORD: VAULT[development/artifactory/token/SonarSource-sonar-scanner-jenkins-qa-deployer access_token]
   ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
-
-  GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
-  PROMOTE_URL: VAULT[development/kv/data/promote data.url]
+  ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
 
   BURGR_URL: VAULT[development/kv/data/burgr data.url]
   BURGR_USERNAME: VAULT[development/kv/data/burgr data.cirrus_username]


### PR DESCRIPTION
Will drop build the warning `[WARN] Obsolete build promotion. The feature is marked for removal starting November 30, 2023.` by moving away from the Google Cloud function previously used to handle the build promotion

https://sonarsource.atlassian.net/browse/SONARJNKNS-371