### PR TITLE
SONARJNKNS-374 Fix withSonarQubeEnv step hanging due to symlinks (agent node compatible)

### DIFF
--- a/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
+++ b/src/main/java/hudson/plugins/sonar/utils/SonarUtils.java
@@ -22,6 +22,7 @@ package hudson.plugins.sonar.utils;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.model.Action;
 import hudson.model.Actionable;
 import hudson.model.Result;
@@ -31,6 +32,8 @@ import hudson.plugins.sonar.SonarInstallation;
 import hudson.plugins.sonar.action.SonarAnalysisAction;
 import hudson.plugins.sonar.client.HttpClient;
 import hudson.plugins.sonar.client.WsClient;
+import hudson.remoting.VirtualChannel;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -44,6 +47,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+import jenkins.MasterToSlaveFileCallable;
+import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.types.FileSet;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 public final class SonarUtils {
@@ -94,7 +101,7 @@ public final class SonarUtils {
   public static Properties extractReportTask(TaskListener listener, FilePath workspace) throws IOException, InterruptedException {
     FilePath[] candidates = null;
     if (workspace.exists()) {
-      candidates = workspace.list("**/" + REPORT_TASK_FILE_NAME);
+      candidates = workspace.act(new ListWithoutSymlinksCallable("**/" + REPORT_TASK_FILE_NAME));
     }
     if (candidates == null || candidates.length == 0) {
       listener.getLogger().println("WARN: Unable to locate '" + REPORT_TASK_FILE_NAME + "' in the workspace. Did the SonarScanner succeed?");
@@ -112,6 +119,34 @@ public final class SonarUtils {
       }
     }
 
+  }
+
+  /**
+   * Similar to what is used for {@link FilePath#list(String)} but does not follow symlinks.
+   */
+  private static class ListWithoutSymlinksCallable extends MasterToSlaveFileCallable<FilePath[]> {
+    private static final long serialVersionUID = 1L;
+    private final String includes;
+
+    ListWithoutSymlinksCallable(String includes) {
+      this.includes = includes;
+    }
+
+    @Override
+    public FilePath[] invoke(File dir, VirtualChannel channel) {
+      FileSet fs = Util.createFileSet(dir, includes, null);
+      fs.setDefaultexcludes(true);
+      fs.setFollowSymlinks(false);
+
+      DirectoryScanner ds = fs.getDirectoryScanner(new Project());
+      String[] includedFiles = ds.getIncludedFiles();
+
+      FilePath[] filePaths = new FilePath[includedFiles.length];
+      for (int i = 0; i < filePaths.length; i++) {
+        filePaths[i] = new FilePath(new File(dir, includedFiles[i]));
+      }
+      return filePaths;
+    }
   }
 
   @Nullable

--- a/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
+++ b/src/test/java/hudson/plugins/sonar/utils/SonarUtilsTest.java
@@ -36,10 +36,14 @@ import java.io.PrintStream;
 import java.io.StringReader;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
+import static hudson.plugins.sonar.utils.SonarUtils.REPORT_TASK_FILE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -53,6 +57,8 @@ import static org.mockito.Mockito.when;
 public class SonarUtilsTest {
   @Rule
   public ExpectedException exception = ExpectedException.none();
+  @Rule
+  public TemporaryFolder workspaceFolder = new TemporaryFolder();
 
   @Test
   public void testMajorMinor() {
@@ -90,6 +96,33 @@ public class SonarUtilsTest {
     assertThat(action.isSkipped()).isFalse();
     assertThat(action.getCeTaskId()).isNull();
     assertThat(action.getUrl()).isEqualTo("url1");
+  }
+
+  @Test
+  public void testAddBuildInfoTo() throws Exception {
+    AbstractBuild<?, ?> build = mockedBuild("log");
+
+    File scannerFolder = workspaceFolder.newFolder("scanner");
+    FileUtils.writeLines(new File(scannerFolder, REPORT_TASK_FILE_NAME), List.of(
+      "serverUrl=http://url",
+      "dashboardUrl=http://url/dashboard?id=test",
+      "ceTaskId=AYzPsI8CN2oYarIFiK6r"
+    ));
+
+    SonarInstallation sonarInstallation = new SonarInstallation("inst", "https://url.com", "credentialsId", null, null, null, null, null,
+      null);
+    SonarAnalysisAction action = SonarUtils.addBuildInfoTo(build, mock(TaskListener.class), new FilePath(workspaceFolder.getRoot()),
+      sonarInstallation, "credId", false);
+
+    assertThat(action.getInstallationName()).isEqualTo("inst");
+    assertThat(action.getInstallationUrl()).isEqualTo("https://url.com");
+    assertThat(action.getCredentialsId()).isEqualTo("credId");
+    assertThat(action.isSkipped()).isFalse();
+    assertThat(action.getCeTaskId()).isEqualTo("AYzPsI8CN2oYarIFiK6r");
+    assertThat(action.getUrl()).isEqualTo("http://url/dashboard?id=test");
+    assertThat(action.getServerUrl()).isEqualTo("http://url");
+
+    verify(build).addAction(action);
   }
 
   @Test


### PR DESCRIPTION
The first fix was breaking builds running on agent nodes (https://github.com/SonarSource/sonar-scanner-jenkins/pull/286, reverted in https://github.com/SonarSource/sonar-scanner-jenkins/pull/287)