### PR TITLE
[NO-JIRA] Improve CSP compatibility

### DIFF
--- a/src/main/java/hudson/plugins/sonar/SonarGlobalConfiguration.java
+++ b/src/main/java/hudson/plugins/sonar/SonarGlobalConfiguration.java
@@ -150,7 +150,7 @@ public class SonarGlobalConfiguration extends GlobalConfiguration implements Ser
     return true;
   }
 
-  public FormValidation doCheckMandatory(@QueryParameter String value) {
+  public FormValidation doCheckName(@QueryParameter String value) {
     return StringUtils.isBlank(value) ? FormValidation.error(Messages.SonarGlobalConfiguration_MandatoryProperty()) : FormValidation.ok();
   }
 

--- a/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarGlobalConfiguration/config.jelly
@@ -11,8 +11,8 @@
       <div class="sonar-section">
       <f:repeatable var="inst" items="${instance.installations}" add="${%AddSonar}">
         <s:blockWrapper class="sonar-installation">
-          <f:entry title="${%Name}">
-            <f:textbox name="sonar.name" value="${inst.getName()}" checkUrl="'${rootURL}/descriptor/SonarGlobalConfiguration/checkMandatory?value='+escape(this.value)"/>
+          <f:entry title="${%Name}" field="name">
+            <f:textbox name="sonar.name" value="${inst.getName()}"/>
           </f:entry>
           
           <f:entry title="${%ServerUrl}" description="${%ServerUrlDescr}">

--- a/src/main/resources/hudson/plugins/sonar/SonarPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarPublisher/config.jelly
@@ -38,7 +38,7 @@
 
     <j:set var="jdks" value="${app.JDKs}" />
     <f:entry title="JDK" description="${%JDKDesc}" help="/plugin/sonar/help-sonar-jdk.html">
-      <select class="setting-input validated" name="sonar.jdk" checkUrl="'${rootURL}/defaultJDKCheck?value='+this.value">
+      <select class="setting-input validated" name="sonar.jdk" checkUrl="${rootURL}/defaultJDKCheck" checkdependson="">
         <option value="">${%InheritFromJob}</option>
         <j:forEach var="inst" items="${jdks}">
           <f:option selected="${inst.name==instance.getJdkName()}" value="${inst.name}">${inst.name}</f:option>

--- a/src/main/resources/hudson/plugins/sonar/SonarRunnerBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/sonar/SonarRunnerBuilder/config.jelly
@@ -23,7 +23,7 @@
   <!-- JDK -->
   <j:set var="jdks" value="${app.JDKs}" />
   <f:entry title="JDK" description="${%JDKDesc}" help="/plugin/sonar/help-sonar-jdk.html">
-    <select class="setting-input validated" name="sonar.jdk" checkUrl="'${rootURL}/defaultJDKCheck?value='+this.value">
+    <select class="setting-input validated" name="sonar.jdk" checkUrl="${rootURL}/defaultJDKCheck" checkDependsOn="">
       <option>${%InheritFromJob}</option>
       <j:forEach var="inst" items="${jdks}">
         <f:option selected="${inst.name==instance.jdkFromJenkins.name}" value="${inst.name}">${inst.name}</f:option>

--- a/src/test/java/hudson/plugins/sonar/SonarGlobalConfigurationTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarGlobalConfigurationTest.java
@@ -86,11 +86,11 @@ public class SonarGlobalConfigurationTest extends SonarTestCase {
   }
 
   @Test
-  public void testMandatory() {
-    assertThat(globalConfiguration.doCheckMandatory("").kind).isEqualTo(Kind.ERROR);
-    assertThat(globalConfiguration.doCheckMandatory(null).kind).isEqualTo(Kind.ERROR);
-    assertThat(globalConfiguration.doCheckMandatory("   ").kind).isEqualTo(Kind.ERROR);
-    assertThat(globalConfiguration.doCheckMandatory("asd").kind).isEqualTo(Kind.OK);
+  public void testNameValidation() {
+    assertThat(globalConfiguration.doCheckName("").kind).isEqualTo(Kind.ERROR);
+    assertThat(globalConfiguration.doCheckName(null).kind).isEqualTo(Kind.ERROR);
+    assertThat(globalConfiguration.doCheckName("   ").kind).isEqualTo(Kind.ERROR);
+    assertThat(globalConfiguration.doCheckName("asd").kind).isEqualTo(Kind.OK);
   }
 
   @Test


### PR DESCRIPTION
There's an ongoing Content Security Project in Jenkins ([blog post](https://www.jenkins.io/blog/2024/10/04/content-security-policy-grant/) in case you want to know more) where we work towards making plugins CSP compatible. So now it's sonar-scanner's turn.

The plugin that we rely on while testing is [Content Security Policy](https://plugins.jenkins.io/csp/).

The issues that this PR addresses are:

- https://issues.jenkins.io/browse/JENKINS-74020
- https://issues.jenkins.io/browse/JENKINS-74021
- https://issues.jenkins.io/browse/JENKINS-74022

Rule that's broken in all three places is https://www.jenkins.io/doc/developer/security/csp/#legacy-javascript-checkurl-validation.

### Testing done
As I said we're relying on the CSP plugin. It has two modes: 
 - Report only mode collecting violations but letting the "bad" code run
 - Restrictive mode that's not letting the "bad" code run

You'll see me switching between modes and showing the behavior before and after my changes.

For `SonarPublisher/config.jelly`:
[Before the change](https://www.youtube.com/watch?v=REY9CBIqRy8)
[After the change](https://www.youtube.com/watch?v=xSqI534w_5E)

For `SonarRunnerBuilder/config.jelly`:\
[Before the change](https://www.youtube.com/watch?v=2K2HaR-4riU)
[After the change](https://www.youtube.com/watch?v=nVRPE1TpPv8)

For `SonarGlobalConfiguration/config.jelly`:
[Before the change](https://www.youtube.com/watch?v=luWmkWlOuE0)
[After the change](https://www.youtube.com/watch?v=-nKO7b-xxJo)
