### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <!-- See https://github.com/jenkinsci/plugin-pom/releases -->
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 
@@ -49,7 +49,9 @@
     <sonar.exclusions>target/generated-sources/**/*</sonar.exclusions>
     <gitRepositoryName>sonar-scanner-jenkins</gitRepositoryName>
     <version.artifactory.plugin>3.6.1</version.artifactory.plugin>
-    <jenkins.version>2.462.3</jenkins.version>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <version.cyclonedx.plugin>2.7.9</version.cyclonedx.plugin>
     <!-- Disable parallel tests on Travis -->
     <concurrency>1</concurrency>
@@ -72,8 +74,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.462.x</artifactId>
-        <version>3387.v0f2773fa_3200</version>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3893.v213a_42768d35</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -145,7 +147,6 @@
       <!-- needed for SonarPublisher -->
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>3.23</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -169,12 +170,10 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
       <optional>true</optional>
-      <version>1368.vb_b_402e3547e7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1381.v2c3a_12074da_b_</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/MsBuildSQRunnerInstallation.java
@@ -41,7 +41,7 @@ import java.util.List;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public class MsBuildSQRunnerInstallation extends ToolInstallation implements EnvironmentSpecific<MsBuildSQRunnerInstallation>, NodeSpecific<MsBuildSQRunnerInstallation> {
   private static final long serialVersionUID = 1L;
@@ -110,7 +110,7 @@ public class MsBuildSQRunnerInstallation extends ToolInstallation implements Env
     }
 
     @Override
-    public MsBuildSQRunnerInstallation newInstance(StaplerRequest req, JSONObject formData) {
+    public MsBuildSQRunnerInstallation newInstance(StaplerRequest2 req, JSONObject formData) {
       return (MsBuildSQRunnerInstallation) req.bindJSON(clazz, formData);
     }
 

--- a/src/main/java/hudson/plugins/sonar/SonarGlobalConfiguration.java
+++ b/src/main/java/hudson/plugins/sonar/SonarGlobalConfiguration.java
@@ -45,7 +45,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Since 2.4
@@ -140,7 +140,7 @@ public class SonarGlobalConfiguration extends GlobalConfiguration implements Ser
   }
 
   @Override
-  public boolean configure(StaplerRequest req, JSONObject json) {
+  public boolean configure(StaplerRequest2 req, JSONObject json) {
     List<SonarInstallation> list = req.bindJSONToList(SonarInstallation.class, json.get("inst"));
     boolean enableBuildWrapper = json.getBoolean("enableBuildWrapper");
     setInstallations(list.toArray(new SonarInstallation[list.size()]));

--- a/src/main/java/hudson/plugins/sonar/SonarRunnerInstallation.java
+++ b/src/main/java/hudson/plugins/sonar/SonarRunnerInstallation.java
@@ -42,7 +42,7 @@ import java.util.List;
 import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Represents a SonarQube Scanner installation in a system.
@@ -126,7 +126,7 @@ public class SonarRunnerInstallation extends ToolInstallation implements Environ
     }
 
     @Override
-    public SonarRunnerInstallation newInstance(StaplerRequest req, JSONObject formData) {
+    public SonarRunnerInstallation newInstance(StaplerRequest2 req, JSONObject formData) {
       return (SonarRunnerInstallation) req.bindJSON(clazz, formData);
     }
 

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHook.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHook.java
@@ -34,13 +34,13 @@ import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 @Extension
@@ -68,7 +68,7 @@ public class SonarQubeWebHook implements UnprotectedRootAction {
   }
 
   @RequirePOST
-  public void doIndex(StaplerRequest req, StaplerResponse rsp) throws IOException {
+  public void doIndex(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
     String payload = IOUtils.toString(req.getReader());
 
     LOGGER.info("Received POST from " + req.getRemoteHost());

--- a/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookCrumbExclusion.java
+++ b/src/main/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookCrumbExclusion.java
@@ -22,10 +22,10 @@ package org.sonarsource.scanner.jenkins.pipeline;
 import hudson.Extension;
 import hudson.security.csrf.CrumbExclusion;
 import java.io.IOException;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 

--- a/src/test/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookCrumbExclusionTest.java
+++ b/src/test/java/org/sonarsource/scanner/jenkins/pipeline/SonarQubeWebHookCrumbExclusionTest.java
@@ -19,9 +19,9 @@
  */
 package org.sonarsource.scanner.jenkins.pipeline;
 
-import javax.servlet.FilterChain;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
Migrate from deprecated EE 8 functionality to non-deprecated EE 9 equivalents. See https://github.com/jenkinsci/lockable-resources-plugin/pull/743#issuecomment-2598199297 for more background. Tested with `mvn clean verify`.

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SONARJNKNS) ticket available, please make your commits and pull request start with the ticket ID (SONARJNKNS-XXXX)