### PR TITLE
fix: Maven SonarQube Scanner expects SONAR_TOKEN to be set in the environment

### DIFF
--- a/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
+++ b/its/src/test/java/com/sonar/it/jenkins/SonarPluginTest.java
@@ -254,6 +254,7 @@ public class SonarPluginTest extends SonarPluginTestSuite {
 
   private void verifySonarqubeEnvVarsExist(String logs) {
     assertThat(logs).contains("SONAR_AUTH_TOKEN=");
+    assertThat(logs).contains("SONAR_TOKEN=");
     assertThat(logs).contains("SONAR_CONFIG_NAME=" + DEFAULT_SONARQUBE_INSTALLATION);
     assertThat(logs).contains("SONAR_HOST_URL=" + ORCHESTRATOR.getServer().getUrl());
     assertThat(logs).contains("SONAR_MAVEN_GOAL=sonar:sonar");

--- a/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sonar/SonarBuildWrapper.java
@@ -135,6 +135,7 @@ public class SonarBuildWrapper extends SimpleBuildWrapper {
     map.put("SONAR_HOST_URL", hostUrl);
     String token = getOrDefault(SonarUtils.getAuthenticationToken(build, inst, credentialsId), "");
     map.put("SONAR_AUTH_TOKEN", token);
+    map.put("SONAR_TOKEN", token);
 
     String mojoVersion = inst.getMojoVersion();
     if (StringUtils.isEmpty(mojoVersion)) {

--- a/src/main/webapp/help-buildWrapper.html
+++ b/src/main/webapp/help-buildWrapper.html
@@ -6,6 +6,7 @@
 	<ul>
 		<li>SONAR_HOST_URL</li>
 		<li>SONAR_AUTH_TOKEN</li>
+		<li>SONAR_TOKEN</li>
 		<li>SONAR_EXTRA_PROPS</li>
 		<li>SONAR_MAVEN_GOAL - supplies the correct Maven goal based on the "Version of sonar-maven-plugin" specified for the SonarQube instance.</li>
 	</ul>

--- a/src/test/java/hudson/plugins/sonar/SonarBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sonar/SonarBuildWrapperTest.java
@@ -137,6 +137,7 @@ public class SonarBuildWrapperTest extends SonarTestCase {
     assertThat(map).containsEntry("SONAR_CONFIG_NAME", "local");
     // variable in the value should be resolved
     assertThat(map).containsEntry("SONAR_AUTH_TOKEN", MYTOKEN);
+    assertThat(map).containsEntry("SONAR_TOKEN", MYTOKEN);
     assertThat(map).containsEntry("SONAR_MAVEN_GOAL", "sonar:sonar");
     assertThat(map).containsEntry("SONAR_EXTRA_PROPS", "-Dkey=myValue -X");
 
@@ -203,6 +204,7 @@ public class SonarBuildWrapperTest extends SonarTestCase {
     // ensure that vars were injected to the job
     assertThat(b.vars).containsEntry("SONAR_HOST_URL", "http://localhost:9001");
     assertThat(b.vars).containsEntry("SONAR_AUTH_TOKEN", MYTOKEN);
+    assertThat(b.vars).containsEntry("SONAR_TOKEN", MYTOKEN);
     assertThat(b.vars).containsEntry("SONAR_EXTRA_PROPS", "-Dkey=value -X");
 
     // job's log should have passwords masked


### PR DESCRIPTION
- The maven sonar scanner in Jenkins expects SONAR_TOKEN to be set. If not you have to explicitly set sonar.token
