### PR TITLE
NO-JIRA Temporarily disable nightly QA

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,6 +68,7 @@ linux_qa_task:
   depends_on:
     - build
   <<: *ONLY_QA
+  <<: *EXCEPT_ON_NIGHTLY_CRON # To be removed later; kill the noise while we discuss our strategy for Jenkins and the ITs
   eks_container: *CONTAINER_TEMPLATE
   env:
     BROWSER: chrome


### PR DESCRIPTION
The QA has been failing for months and creates a lot of noise. Until we can invest heavily into rethinking the ITs and this project as a whole, we want to silence the nightly builds.
