### PR TITLE
SONARJNKNS-405 Bump mise to 2026.3.10 to fix freethreaded Python build selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
-          version: 2025.7.12
+          version: 2026.3.10
       - uses: SonarSource/ci-github-actions/build-maven@v1
         with:
           deploy-pull-request: true
@@ -62,7 +62,7 @@ jobs:
 
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
-          version: 2025.7.12
+          version: 2026.3.10
 
       - name: Download build artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -101,7 +101,7 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           cache_save: false
-          version: 2025.7.12
+          version: 2026.3.10
       - uses: SonarSource/ci-github-actions/promote@v1
         with:
           promote-pull-request: true


### PR DESCRIPTION
## Summary
- Bump mise from 2025.7.12 to 2026.3.10 to fix freethreaded Python build selection bug

## Context
Mise v2025.x incorrectly selected freethreaded (no-GIL) Python builds, causing `mise ERROR failed to install core:python` failures in CI.